### PR TITLE
test(ui): verify track collections sort

### DIFF
--- a/apps/rpg-maestro-ui/src/app/maestro-ui/track-collections/track-collections.spec.tsx
+++ b/apps/rpg-maestro-ui/src/app/maestro-ui/track-collections/track-collections.spec.tsx
@@ -93,4 +93,37 @@ describe('TrackCollectionsComponent', () => {
     expect(screen.getByText('ambient')).toBeTruthy();
     expect(screen.getByText('1:30')).toBeTruthy();
   });
+
+  it('sorts track collections by updated_at desc', async () => {
+    getAllTrackCollectionsMock.mockResolvedValue([
+      {
+        id: 'collection-1',
+        name: 'Older',
+        description: null,
+        tracks: [],
+        created_at: 0,
+        updated_at: 100,
+        created_by: 'user-1',
+      },
+      {
+        id: 'collection-2',
+        name: 'Newer',
+        description: null,
+        tracks: [],
+        created_at: 0,
+        updated_at: 200,
+        created_by: 'user-1',
+      },
+    ]);
+
+    render(<TrackCollectionsComponent />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Newer')).toBeTruthy();
+    });
+
+    const rows = screen.getAllByRole('row');
+    const firstDataRow = rows[1];
+    expect(firstDataRow.textContent).toContain('Newer');
+  });
 });


### PR DESCRIPTION
## Summary
- add a unit test ensuring track collections sort by most recent updated_at

## Tests
- npx nx test rpg-maestro-ui --testFile=apps/rpg-maestro-ui/src/app/maestro-ui/track-collections/track-collections.spec.tsx