### PR TITLE
feat: maestro can import track collections into a running session

### DIFF
--- a/apps/rpg-maestro-ui/src/app/maestro-ui/maestro-api.ts
+++ b/apps/rpg-maestro-ui/src/app/maestro-ui/maestro-api.ts
@@ -217,6 +217,22 @@ export const getMaestroInfos = async (): Promise<User> => {
   }
 };
 
+export const importCollectionToSession = async (sessionId: string, collectionId: string): Promise<Track[]> => {
+  try {
+    const response = await authenticatedFetch(
+      `${rpgmaestroapiurl}/maestro/sessions/${sessionId}/tracks/from-collection/${collectionId}`,
+      {
+        method: 'POST',
+        credentials: 'include',
+      }
+    );
+    return response as Track[];
+  } catch (error) {
+    console.error(error);
+    return Promise.reject(error);
+  }
+};
+
 export const getUserFromAPI = async (): Promise<User> => {
   try {
     const response = await authenticatedFetch(`${rpgMaestroApiUrl}/users/me`, {});

--- a/apps/rpg-maestro-ui/src/app/maestro-ui/maestro-soundboard.tsx
+++ b/apps/rpg-maestro-ui/src/app/maestro-ui/maestro-soundboard.tsx
@@ -5,7 +5,7 @@ import { AbortedRequestError, getAllTracks, setTrackToPlay } from './maestro-api
 import { ToastContainer } from 'react-toastify';
 import SearchSpecificTrack from './tracks-table/SearchSpecificTrack';
 import { TextLinkWithIconWrapper } from '../ui-components/text-link-with-icon-wrapper';
-import { LyricsTwoTone, Visibility } from '@mui/icons-material';
+import { CollectionsBookmarkTwoTone, LyricsTwoTone, Visibility } from '@mui/icons-material';
 import SearchTags from './tracks-table/SearchTags';
 import { QuickTagSelection } from './tracks-table/quick-tag-selection';
 import ShieldIcon from '@mui/icons-material/Shield';
@@ -146,11 +146,18 @@ function MaestroSoundboardComponent() {
           materialUiIcon={Visibility}
         />
         {user && (user.role === 'MAESTRO' || user.role === 'ADMIN') ? (
-          <TextLinkWithIconWrapper
-            link={`/maestro/manage/${sessionId}`}
-            text={'Manage your tracks'}
-            materialUiIcon={LyricsTwoTone}
-          />
+          <div style={{ display: 'flex', flexDirection: 'column', gap: '0.5rem', alignItems: 'flex-end' }}>
+            <TextLinkWithIconWrapper
+              link={`/maestro/manage/${sessionId}`}
+              text={'Manage your tracks'}
+              materialUiIcon={LyricsTwoTone}
+            />
+            <TextLinkWithIconWrapper
+              link={`/maestro/track-collections?sessionId=${sessionId}`}
+              text={'Track collections'}
+              materialUiIcon={CollectionsBookmarkTwoTone}
+            />
+          </div>
         ) : (
           ''
         )}

--- a/apps/rpg-maestro-ui/src/app/maestro-ui/track-collections/track-collections.spec.tsx
+++ b/apps/rpg-maestro-ui/src/app/maestro-ui/track-collections/track-collections.spec.tsx
@@ -1,4 +1,5 @@
 import { render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
 import { vi } from 'vitest';
 
 import { TrackCollectionsComponent } from './track-collections';
@@ -36,7 +37,11 @@ describe('TrackCollectionsComponent', () => {
       },
     ]);
 
-    render(<TrackCollectionsComponent />);
+    render(
+      <MemoryRouter>
+        <TrackCollectionsComponent />
+      </MemoryRouter>,
+    );
 
     expect(screen.getByText('Loading track collections...')).toBeTruthy();
 

--- a/apps/rpg-maestro-ui/src/app/maestro-ui/track-collections/track-collections.stories.tsx
+++ b/apps/rpg-maestro-ui/src/app/maestro-ui/track-collections/track-collections.stories.tsx
@@ -74,7 +74,7 @@ export const WithSessionId: Story = {
     errorMessage: null,
     sessionId: 'session-123',
     onImport: async (collectionId: string) => {
-      console.log('Import collection', collectionId);
+      console.info('Import collection', collectionId);
     },
     trackCollections: [
       {

--- a/apps/rpg-maestro-ui/src/app/maestro-ui/track-collections/track-collections.stories.tsx
+++ b/apps/rpg-maestro-ui/src/app/maestro-ui/track-collections/track-collections.stories.tsx
@@ -67,3 +67,38 @@ export const Empty: Story = {
     trackCollections: [],
   },
 };
+
+export const WithSessionId: Story = {
+  args: {
+    isLoading: false,
+    errorMessage: null,
+    sessionId: 'session-123',
+    onImport: async (collectionId: string) => {
+      console.log('Import collection', collectionId);
+    },
+    trackCollections: [
+      {
+        id: 'collection-1',
+        name: 'Dungeon Crawl',
+        description: 'Dark and tense loops',
+        tracks: [
+          {
+            id: 'track-1',
+            source: { origin_media: 'remote', origin_url: 'http://localhost/intro', origin_name: 'Remote' },
+            name: 'Intro',
+            tags: ['dungeon'],
+            url: 'http://localhost/intro',
+            duration: 120,
+          },
+        ],
+        created_at: 0,
+        updated_at: 0,
+        created_by: 'user-1',
+      },
+    ],
+  },
+  play: async ({ canvasElement }: { canvasElement: HTMLElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText('Import to session')).toBeTruthy();
+  },
+};

--- a/apps/rpg-maestro-ui/src/app/maestro-ui/track-collections/track-collections.tsx
+++ b/apps/rpg-maestro-ui/src/app/maestro-ui/track-collections/track-collections.tsx
@@ -124,7 +124,7 @@ export function TrackCollectionsComponent() {
         if (isActive) {
           setTrackCollections(collections);
         }
-      } catch (error) {
+      } catch {
         if (isActive) {
           setErrorMessage('Unable to load track collections.');
         }

--- a/apps/rpg-maestro-ui/src/app/maestro-ui/track-collections/track-collections.tsx
+++ b/apps/rpg-maestro-ui/src/app/maestro-ui/track-collections/track-collections.tsx
@@ -8,7 +8,7 @@ import { Loading } from '../../auth/Loading';
 import { TextLinkWithIconWrapper } from '../../ui-components/text-link-with-icon-wrapper';
 import { isDevModeEnabled } from '../../../FeaturesConfiguration';
 import { formatTodayDate } from '../../utils/time';
-import { useSearchParams } from 'react-router';
+import { useSearchParams } from 'react-router-dom';
 import { toast, ToastContainer } from 'react-toastify';
 
 type TrackCollectionsContentProps = {

--- a/apps/rpg-maestro-ui/src/app/maestro-ui/track-collections/track-collections.tsx
+++ b/apps/rpg-maestro-ui/src/app/maestro-ui/track-collections/track-collections.tsx
@@ -3,19 +3,51 @@ import { TrackCollection } from '@rpg-maestro/rpg-maestro-api-contract';
 import { withAuthenticationRequired } from '@auth0/auth0-react';
 import KeyboardReturnIcon from '@mui/icons-material/KeyboardReturn';
 
-import { getAllTrackCollections } from '../maestro-api';
+import { getAllTrackCollections, importCollectionToSession } from '../maestro-api';
 import { Loading } from '../../auth/Loading';
 import { TextLinkWithIconWrapper } from '../../ui-components/text-link-with-icon-wrapper';
 import { isDevModeEnabled } from '../../../FeaturesConfiguration';
 import { formatTodayDate } from '../../utils/time';
+import { useSearchParams } from 'react-router';
+import { toast } from 'react-toastify';
 
 type TrackCollectionsContentProps = {
   trackCollections: TrackCollection[];
   isLoading: boolean;
   errorMessage: string | null;
+  sessionId?: string;
+  onImport?: (collectionId: string) => Promise<void>;
 };
 
-export function TrackCollectionsContent({ trackCollections, isLoading, errorMessage }: TrackCollectionsContentProps) {
+export function TrackCollectionsContent({
+  trackCollections,
+  isLoading,
+  errorMessage,
+  sessionId,
+  onImport,
+}: TrackCollectionsContentProps) {
+  const [importingIds, setImportingIds] = useState<Set<string>>(new Set());
+
+  const handleImport = async (collectionId: string) => {
+    if (!onImport) return;
+    setImportingIds((prev) => new Set(prev).add(collectionId));
+    try {
+      await onImport(collectionId);
+      toast.success('Collection imported successfully');
+    } catch {
+      toast.error('Failed to import collection');
+    } finally {
+      setImportingIds((prev) => {
+        const next = new Set(prev);
+        next.delete(collectionId);
+        return next;
+      });
+    }
+  };
+
+  const backLink = sessionId ? `/maestro/${sessionId}` : '/maestro/admin';
+  const backText = sessionId ? 'Back to session' : 'Back to admin';
+
   return (
     <div
       style={{
@@ -28,7 +60,7 @@ export function TrackCollectionsContent({ trackCollections, isLoading, errorMess
       }}
     >
       <div style={{ display: 'flex', flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center' }}>
-        <TextLinkWithIconWrapper link="/maestro/admin" text="Back to admin" materialUiIcon={KeyboardReturnIcon} />
+        <TextLinkWithIconWrapper link={backLink} text={backText} materialUiIcon={KeyboardReturnIcon} />
         <h1 style={{ margin: 0 }}>Track collections</h1>
       </div>
       <hr style={{ width: '100vw', borderColor: 'var(--gold-color)' }} />
@@ -43,6 +75,7 @@ export function TrackCollectionsContent({ trackCollections, isLoading, errorMess
               <th style={{ textAlign: 'left', padding: '0.5rem' }}>Description</th>
               <th style={{ textAlign: 'left', padding: '0.5rem' }}>Updated</th>
               <th style={{ textAlign: 'right', padding: '0.5rem' }}>Tracks</th>
+              {sessionId && <th style={{ textAlign: 'right', padding: '0.5rem' }}>Actions</th>}
             </tr>
           </thead>
           <tbody>
@@ -54,6 +87,16 @@ export function TrackCollectionsContent({ trackCollections, isLoading, errorMess
                   <td style={{ padding: '0.5rem' }}>{collection.description ?? '-'}</td>
                   <td style={{ padding: '0.5rem' }}>{formatTodayDate(collection.updated_at)}</td>
                   <td style={{ padding: '0.5rem', textAlign: 'right' }}>{collection.tracks.length}</td>
+                  {sessionId && (
+                    <td style={{ padding: '0.5rem', textAlign: 'right' }}>
+                      <button
+                        onClick={() => handleImport(collection.id)}
+                        disabled={importingIds.has(collection.id)}
+                      >
+                        {importingIds.has(collection.id) ? 'Importing...' : 'Import to session'}
+                      </button>
+                    </td>
+                  )}
                 </tr>
               ))}
           </tbody>
@@ -67,6 +110,8 @@ export function TrackCollectionsComponent() {
   const [trackCollections, setTrackCollections] = useState<TrackCollection[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [searchParams] = useSearchParams();
+  const sessionId = searchParams.get('sessionId') ?? undefined;
 
   useEffect(() => {
     let isActive = true;
@@ -94,8 +139,19 @@ export function TrackCollectionsComponent() {
     };
   }, []);
 
+  const handleImport = async (collectionId: string) => {
+    if (!sessionId) return;
+    await importCollectionToSession(sessionId, collectionId);
+  };
+
   return (
-    <TrackCollectionsContent trackCollections={trackCollections} isLoading={isLoading} errorMessage={errorMessage} />
+    <TrackCollectionsContent
+      trackCollections={trackCollections}
+      isLoading={isLoading}
+      errorMessage={errorMessage}
+      sessionId={sessionId}
+      onImport={sessionId ? handleImport : undefined}
+    />
   );
 }
 

--- a/apps/rpg-maestro-ui/src/app/maestro-ui/track-collections/track-collections.tsx
+++ b/apps/rpg-maestro-ui/src/app/maestro-ui/track-collections/track-collections.tsx
@@ -9,7 +9,7 @@ import { TextLinkWithIconWrapper } from '../../ui-components/text-link-with-icon
 import { isDevModeEnabled } from '../../../FeaturesConfiguration';
 import { formatTodayDate } from '../../utils/time';
 import { useSearchParams } from 'react-router';
-import { toast } from 'react-toastify';
+import { toast, ToastContainer } from 'react-toastify';
 
 type TrackCollectionsContentProps = {
   trackCollections: TrackCollection[];
@@ -102,6 +102,7 @@ export function TrackCollectionsContent({
           </tbody>
         </table>
       )}
+      <ToastContainer limit={5} />
     </div>
   );
 }

--- a/apps/rpg-maestro-ui/src/app/onboarding/setup-session.tsx
+++ b/apps/rpg-maestro-ui/src/app/onboarding/setup-session.tsx
@@ -49,6 +49,7 @@ export function SetupSession() {
 
   useEffect(() => {
     sendOnboardRequest();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   useEffect(() => {

--- a/apps/rpg-maestro-ui/src/app/ui-components/menu.tsx
+++ b/apps/rpg-maestro-ui/src/app/ui-components/menu.tsx
@@ -3,7 +3,6 @@ import Button from '@mui/material/Button';
 import Menu from '@mui/material/Menu';
 import MenuItem from '@mui/material/MenuItem';
 import { useNavigate } from 'react-router-dom';
-import { clearUserFromSessionStorage } from '../cache/session-storage.service';
 import { useAuth0 } from '@auth0/auth0-react';
 
 export default function BasicMenu() {

--- a/apps/rpg-maestro/src/app/AuthenticatedMaestroController.ts
+++ b/apps/rpg-maestro/src/app/AuthenticatedMaestroController.ts
@@ -37,6 +37,7 @@ import { RolesGuard } from './auth/roles.guard';
 import { Roles } from './auth/roles.decorator';
 import { Role } from './auth/role.enum';
 import { SessionsService } from './sessions/sessions.service';
+import { TrackCollectionService } from './track-collection/track-collection.service';
 
 @ApiCookieAuth()
 @UseGuards(JwtAuthGuard, RolesGuard)
@@ -49,7 +50,8 @@ export class AuthenticatedMaestroController {
     @Inject(SessionsService) sessionsService: SessionsService,
     @Inject(TrackService) private trackService: TrackService,
     @Inject(OnboardingService) private onboardingService: OnboardingService,
-    @Inject(UsersService) private userService: UsersService
+    @Inject(UsersService) private userService: UsersService,
+    @Inject(TrackCollectionService) private trackCollectionService: TrackCollectionService
   ) {
     this.manageCurrentlyPlayingTracks = new ManageCurrentlyPlayingTracks(
       databaseWrapper.getTracksDB(),
@@ -143,6 +145,18 @@ export class AuthenticatedMaestroController {
   ): Promise<SessionPlayingTracks> {
     await this.checkAccessOnSession(req.user, sessionId);
     return await this.manageCurrentlyPlayingTracks.changeSessionPlayingTracks(sessionId, changeSessionPlayingTracks);
+  }
+
+  @Post('/maestro/sessions/:sessionId/tracks/from-collection/:collectionId')
+  @Roles([Role.MAESTRO])
+  async importTracksFromCollection(
+    @Request() req: { user: AuthenticatedUser },
+    @Param('sessionId') sessionId: string,
+    @Param('collectionId') collectionId: string
+  ): Promise<Track[]> {
+    await this.checkAccessOnSession(req.user, sessionId);
+    const collection = await this.trackCollectionService.get(collectionId);
+    return this.trackService.importTracksFromTrackCollection(sessionId, collection);
   }
 
   @Post('/maestro/sessions')

--- a/apps/rpg-maestro/src/app/track-collection/track-collection.e2e.spec.ts
+++ b/apps/rpg-maestro/src/app/track-collection/track-collection.e2e.spec.ts
@@ -176,6 +176,43 @@ describe('TrackCollection', () => {
       .set('Authorization', `Bearer ${A_MAESTRO_USER.token}`)
       .expect(403);
   }, 10000);
+  it('a Maestro can import a TrackCollection into an existing session', async () => {
+    // given a collection
+    await request(app.getHttpServer())
+      .post('/track-collections')
+      .send(trackCollectionCreateRequest)
+      .set('Content-Type', 'application/json')
+      .set('Authorization', `Bearer ${AN_ADMIN_USER.token}`)
+      .expect(201);
+
+    // and a session owned by the maestro
+    const session = (await request(app.getHttpServer())
+      .post('/maestro/sessions')
+      .send({})
+      .set('Content-Type', 'application/json')
+      .set('Authorization', `Bearer ${A_MAESTRO_USER.token}`)
+      .expect(201)).body as SessionPlayingTracks;
+
+    // when
+    const importedTracks = (await request(app.getHttpServer())
+      .post(`/maestro/sessions/${session.sessionId}/tracks/from-collection/${trackCollectionCreateRequest.id}`)
+      .set('Authorization', `Bearer ${A_MAESTRO_USER.token}`)
+      .expect(201)).body as Track[];
+
+    expect(importedTracks).toBeDefined();
+    expect(importedTracks.length).toEqual(trackCollectionCreateRequest.tracks.length);
+    expect(importedTracks[0].name).toEqual(trackCollectionCreateRequest.tracks[0].name);
+    expect(importedTracks[0].tags).toEqual(trackCollectionCreateRequest.tracks[0].tags);
+
+    // and the tracks appear in the session
+    const sessionTracks = (await request(app.getHttpServer())
+      .get(`/maestro/sessions/${session.sessionId}/tracks`)
+      .set('Authorization', `Bearer ${A_MAESTRO_USER.token}`)
+      .expect(200)).body as Track[];
+
+    expect(sessionTracks.length).toEqual(importedTracks.length);
+  }, 10000);
+
   it('cannot create with already existing id', async () => {
     await request(app.getHttpServer())
       .post('/track-collections')


### PR DESCRIPTION
## Summary

- Adds `POST /maestro/sessions/:sessionId/tracks/from-collection/:collectionId` endpoint (MAESTRO only), reusing existing `TrackService.importTracksFromTrackCollection`
- Adds `importCollectionToSession` API function in `maestro-api.ts`
- Track collections page is now session-aware: when opened with `?sessionId=`, it shows an "Import to session" button per row and adjusts the back link
- Maestro soundboard gets a "Track collections" link that passes the current `sessionId` as a query param

## Test plan

- [ ] Backend e2e: `a Maestro can import a TrackCollection into an existing session` in `track-collection.e2e.spec.ts`
- [ ] Storybook: new `WithSessionId` story in `track-collections.stories.tsx` shows import button
- [ ] Manual: from Maestro soundboard, click "Track collections", click "Import to session", verify tracks appear after refresh