### PR TITLE
feat(ui): add soundboard with quick sound effect buttons

### DIFF
--- a/apps/rpg-maestro-ui/src/app/maestro-ui/maestro-api.ts
+++ b/apps/rpg-maestro-ui/src/app/maestro-ui/maestro-api.ts
@@ -27,6 +27,19 @@ export const getAllTracks = async (sessionId: string): Promise<Track[]> => {
   }
 };
 
+export const getSoundboardTracks = async (sessionId: string): Promise<Track[]> => {
+  try {
+    const response = await authenticatedFetch(rpgMaestroApiUrl + `/maestro/sessions/${sessionId}/soundboard-tracks`, {
+      credentials: 'include',
+    });
+    return response as Track[];
+  } catch (error) {
+    console.error(error);
+    displayError(`Fetch /maestro/sessions/${sessionId}/soundboard-tracks error: ${error}`);
+    return [];
+  }
+};
+
 export const getAllTrackCollections = async (): Promise<TrackCollection[]> => {
   try {
     const response = await authenticatedFetch(`${rpgMaestroApiUrl}/track-collections`, {

--- a/apps/rpg-maestro-ui/src/app/maestro-ui/maestro-soundboard.tsx
+++ b/apps/rpg-maestro-ui/src/app/maestro-ui/maestro-soundboard.tsx
@@ -23,6 +23,7 @@ import BasicMenu from '../ui-components/menu';
 import { withAuthenticationRequired } from '@auth0/auth0-react';
 import { Loading } from '../auth/Loading';
 import { isDevModeEnabled } from '../../FeaturesConfiguration';
+import { Soundboard } from './soundboard/soundboard';
 
 function MaestroSoundboardComponent() {
   const [user, setUser] = useState<User | undefined>(undefined);
@@ -163,6 +164,8 @@ function MaestroSoundboardComponent() {
         )}
       </div>
       <div style={{ display: 'flex', justifyContent: 'space-around', alignItems: 'center', gap: '1rem' }}>
+        <div style={{ display: 'flex', flexDirection: 'column', gap: '1rem' }}>
+        <Soundboard />
         <div style={{ display: 'inline-flex', justifyContent: 'flex-start', width: '250px' }}>
           <h5
             style={{
@@ -219,6 +222,7 @@ function MaestroSoundboardComponent() {
               onQuickTagDoubleClick={onQuickTagChange}
             />
           </div>
+        </div>
         </div>
         <div style={{ display: 'inline-flex', justifyContent: 'flex-start', minWidth: '330px' }}>
           <MaestroAudioPlayer

--- a/apps/rpg-maestro-ui/src/app/maestro-ui/maestro-soundboard.tsx
+++ b/apps/rpg-maestro-ui/src/app/maestro-ui/maestro-soundboard.tsx
@@ -1,7 +1,7 @@
 import { filter, TrackFilters, TracksTable } from './tracks-table/tracks-table';
 import React, { useEffect, useRef, useState } from 'react';
 import { SessionPlayingTracks, Tag, Track, TrackToPlay, User } from '@rpg-maestro/rpg-maestro-api-contract';
-import { AbortedRequestError, getAllTracks, setTrackToPlay } from './maestro-api';
+import { AbortedRequestError, getAllTracks, getSoundboardTracks, setTrackToPlay } from './maestro-api';
 import { ToastContainer } from 'react-toastify';
 import SearchSpecificTrack from './tracks-table/SearchSpecificTrack';
 import { TextLinkWithIconWrapper } from '../ui-components/text-link-with-icon-wrapper';
@@ -28,7 +28,8 @@ import { Soundboard } from './soundboard/soundboard';
 function MaestroSoundboardComponent() {
   const [user, setUser] = useState<User | undefined>(undefined);
   const [allTracks, setAllTracks] = useState<Track[] | undefined>(undefined);
-  const [trackFilters, setTrackFilters] = useState<TrackFilters>({});
+  const [soundboardTracks, setSoundboardTracks] = useState<Track[] | undefined>(undefined);
+  const [trackFilters, setTrackFilters] = useState<TrackFilters>({ excludeTags: ['soundboard'] });
   const sessionId = useParams().sessionId ?? '';
   if (sessionId === '') {
     displayError('no session found in URL (it should be https://{URL}/maestro/{sessionId})');
@@ -44,6 +45,9 @@ function MaestroSoundboardComponent() {
   useEffect(() => {
     if (allTracks === undefined) {
       refreshTracks();
+    }
+    if (soundboardTracks === undefined) {
+      getSoundboardTracks(sessionId).then(setSoundboardTracks);
     }
     if (user === undefined) {
       getUser().then((user) => {
@@ -165,7 +169,9 @@ function MaestroSoundboardComponent() {
       </div>
       <div style={{ display: 'flex', justifyContent: 'space-around', alignItems: 'center', gap: '1rem' }}>
         <div style={{ display: 'flex', flexDirection: 'column', gap: '1rem' }}>
-        <Soundboard />
+        {soundboardTracks && soundboardTracks.length > 0 && (
+          <Soundboard tracks={soundboardTracks} onPlay={requestSetTrackToPlay} />
+        )}
         <div style={{ display: 'inline-flex', justifyContent: 'flex-start', width: '250px' }}>
           <h5
             style={{

--- a/apps/rpg-maestro-ui/src/app/maestro-ui/soundboard/soundboard-button.tsx
+++ b/apps/rpg-maestro-ui/src/app/maestro-ui/soundboard/soundboard-button.tsx
@@ -3,20 +3,15 @@ import React from 'react';
 import Button from '@mui/material/Button';
 import { Color } from '../tracks-table/quick-tag-selection';
 
-const MOCK_SOUND_URL = 'https://cdn.freesound.org/previews/848/848968_17559721-lq.mp3';
-
 interface SoundboardButtonProps {
   text: string;
   icon: SvgIconComponent;
   color: Color;
+  onPlay: () => void;
 }
 
-export function SoundboardButton({ text, icon, color }: SoundboardButtonProps) {
+export function SoundboardButton({ text, icon, color, onPlay }: SoundboardButtonProps) {
   const iconInstance = React.createElement(icon, { sx: { fontSize: 50 } });
-
-  const handleClick = () => {
-    new Audio(MOCK_SOUND_URL).play();
-  };
 
   return (
     <Button
@@ -31,7 +26,7 @@ export function SoundboardButton({ text, icon, color }: SoundboardButtonProps) {
         fontWeight: '500',
         backgroundColor: 'rgba(57,57,57,0.15)',
       }}
-      onClick={handleClick}
+      onClick={onPlay}
     >
       <div style={{ display: 'flex', alignItems: 'center' }}>
         {iconInstance}

--- a/apps/rpg-maestro-ui/src/app/maestro-ui/soundboard/soundboard-button.tsx
+++ b/apps/rpg-maestro-ui/src/app/maestro-ui/soundboard/soundboard-button.tsx
@@ -1,0 +1,42 @@
+import { SvgIconComponent } from '@mui/icons-material';
+import React from 'react';
+import Button from '@mui/material/Button';
+import { Color } from '../tracks-table/quick-tag-selection';
+
+const MOCK_SOUND_URL = 'https://cdn.freesound.org/previews/848/848968_17559721-lq.mp3';
+
+interface SoundboardButtonProps {
+  text: string;
+  icon: SvgIconComponent;
+  color: Color;
+}
+
+export function SoundboardButton({ text, icon, color }: SoundboardButtonProps) {
+  const iconInstance = React.createElement(icon, { sx: { fontSize: 50 } });
+
+  const handleClick = () => {
+    new Audio(MOCK_SOUND_URL).play();
+  };
+
+  return (
+    <Button
+      style={{
+        display: 'flex',
+        textDecoration: 'none',
+        color: color,
+        height: '60px',
+        width: '110px',
+        border: '1px solid',
+        fontSize: '11px',
+        fontWeight: '500',
+        backgroundColor: 'rgba(57,57,57,0.15)',
+      }}
+      onClick={handleClick}
+    >
+      <div style={{ display: 'flex', alignItems: 'center' }}>
+        {iconInstance}
+        <p>{text}</p>
+      </div>
+    </Button>
+  );
+}

--- a/apps/rpg-maestro-ui/src/app/maestro-ui/soundboard/soundboard.spec.tsx
+++ b/apps/rpg-maestro-ui/src/app/maestro-ui/soundboard/soundboard.spec.tsx
@@ -1,0 +1,53 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { vi } from 'vitest';
+import { Soundboard } from './soundboard';
+
+const mockTracks = [
+  {
+    id: 'track-thunder',
+    name: 'thunder',
+    tags: ['soundboard'],
+    url: 'http://localhost/thunder.mp3',
+    duration: 5,
+    sessionId: 'session-1',
+    created_at: 0,
+    updated_at: 0,
+    source: { origin_media: 'remote', origin_url: '', origin_name: '' },
+  },
+  {
+    id: 'track-explosion',
+    name: 'explosion',
+    tags: ['soundboard'],
+    url: 'http://localhost/explosion.mp3',
+    duration: 4,
+    sessionId: 'session-1',
+    created_at: 0,
+    updated_at: 0,
+    source: { origin_media: 'remote', origin_url: '', origin_name: '' },
+  },
+];
+
+describe('Soundboard', () => {
+  it('calls onPlay with the correct trackId when a button is clicked', async () => {
+    const onPlay = vi.fn();
+
+    render(<Soundboard tracks={mockTracks} onPlay={onPlay} />);
+
+    await userEvent.click(screen.getByText('thunder'));
+
+    expect(onPlay).toHaveBeenCalledOnce();
+    expect(onPlay).toHaveBeenCalledWith('track-thunder');
+  });
+
+  it('calls onPlay with the correct trackId for a different button', async () => {
+    const onPlay = vi.fn();
+
+    render(<Soundboard tracks={mockTracks} onPlay={onPlay} />);
+
+    await userEvent.click(screen.getByText('explosion'));
+
+    expect(onPlay).toHaveBeenCalledOnce();
+    expect(onPlay).toHaveBeenCalledWith('track-explosion');
+  });
+});

--- a/apps/rpg-maestro-ui/src/app/maestro-ui/soundboard/soundboard.stories.tsx
+++ b/apps/rpg-maestro-ui/src/app/maestro-ui/soundboard/soundboard.stories.tsx
@@ -1,0 +1,26 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { expect } from '@storybook/jest';
+import { within } from '@storybook/testing-library';
+
+import { Soundboard } from './soundboard';
+
+const meta: Meta<typeof Soundboard> = {
+  title: 'Maestro/Soundboard',
+  component: Soundboard,
+};
+
+export default meta;
+
+type Story = StoryObj<typeof Soundboard>;
+
+export const Default: Story = {
+  play: async ({ canvasElement }: { canvasElement: HTMLElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText('thunder')).toBeTruthy();
+    await expect(canvas.getByText('scream')).toBeTruthy();
+    await expect(canvas.getByText('door open')).toBeTruthy();
+    await expect(canvas.getByText('door shut')).toBeTruthy();
+    await expect(canvas.getByText('battle')).toBeTruthy();
+    await expect(canvas.getByText('explosion')).toBeTruthy();
+  },
+};

--- a/apps/rpg-maestro-ui/src/app/maestro-ui/soundboard/soundboard.stories.tsx
+++ b/apps/rpg-maestro-ui/src/app/maestro-ui/soundboard/soundboard.stories.tsx
@@ -13,7 +13,20 @@ export default meta;
 
 type Story = StoryObj<typeof Soundboard>;
 
+const mockTracks = [
+  { id: '1', name: 'thunder', tags: ['soundboard'], url: 'https://cdn.freesound.org/previews/848/848968_17559721-lq.mp3', duration: 5, sessionId: 'demo', created_at: 0, updated_at: 0, source: { origin_media: 'remote', origin_url: '', origin_name: '' } },
+  { id: '2', name: 'scream', tags: ['soundboard'], url: 'https://cdn.freesound.org/previews/848/848968_17559721-lq.mp3', duration: 3, sessionId: 'demo', created_at: 0, updated_at: 0, source: { origin_media: 'remote', origin_url: '', origin_name: '' } },
+  { id: '3', name: 'door open', tags: ['soundboard'], url: 'https://cdn.freesound.org/previews/848/848968_17559721-lq.mp3', duration: 2, sessionId: 'demo', created_at: 0, updated_at: 0, source: { origin_media: 'remote', origin_url: '', origin_name: '' } },
+  { id: '4', name: 'door shut', tags: ['soundboard'], url: 'https://cdn.freesound.org/previews/848/848968_17559721-lq.mp3', duration: 2, sessionId: 'demo', created_at: 0, updated_at: 0, source: { origin_media: 'remote', origin_url: '', origin_name: '' } },
+  { id: '5', name: 'battle', tags: ['soundboard'], url: 'https://cdn.freesound.org/previews/848/848968_17559721-lq.mp3', duration: 10, sessionId: 'demo', created_at: 0, updated_at: 0, source: { origin_media: 'remote', origin_url: '', origin_name: '' } },
+  { id: '6', name: 'explosion', tags: ['soundboard'], url: 'https://cdn.freesound.org/previews/848/848968_17559721-lq.mp3', duration: 4, sessionId: 'demo', created_at: 0, updated_at: 0, source: { origin_media: 'remote', origin_url: '', origin_name: '' } },
+];
+
 export const Default: Story = {
+  args: {
+    tracks: mockTracks,
+    onPlay: (trackId: string) => console.info('play', trackId),
+  },
   play: async ({ canvasElement }: { canvasElement: HTMLElement }) => {
     const canvas = within(canvasElement);
     await expect(canvas.getByText('thunder')).toBeTruthy();
@@ -22,5 +35,18 @@ export const Default: Story = {
     await expect(canvas.getByText('door shut')).toBeTruthy();
     await expect(canvas.getByText('battle')).toBeTruthy();
     await expect(canvas.getByText('explosion')).toBeTruthy();
+  },
+};
+
+export const WithUnknownTrack: Story = {
+  args: {
+    tracks: [
+      { id: '7', name: 'unknown sfx', tags: ['soundboard'], url: 'https://cdn.freesound.org/previews/848/848968_17559721-lq.mp3', duration: 3, sessionId: 'demo', created_at: 0, updated_at: 0, source: { origin_media: 'remote', origin_url: '', origin_name: '' } },
+    ],
+    onPlay: (trackId: string) => console.info('play', trackId),
+  },
+  play: async ({ canvasElement }: { canvasElement: HTMLElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText('unknown sfx')).toBeTruthy();
   },
 };

--- a/apps/rpg-maestro-ui/src/app/maestro-ui/soundboard/soundboard.tsx
+++ b/apps/rpg-maestro-ui/src/app/maestro-ui/soundboard/soundboard.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import { SoundboardButton } from './soundboard-button';
+import ThunderstormIcon from '@mui/icons-material/Thunderstorm';
+import RecordVoiceOverIcon from '@mui/icons-material/RecordVoiceOver';
+import DoorFrontIcon from '@mui/icons-material/DoorFront';
+import MeetingRoomIcon from '@mui/icons-material/MeetingRoom';
+import GpsFixedIcon from '@mui/icons-material/GpsFixed';
+import LocalFireDepartmentIcon from '@mui/icons-material/LocalFireDepartment';
+
+export function Soundboard() {
+  return (
+    <div style={{ display: 'inline-flex', justifyContent: 'flex-start', width: '250px' }}>
+      <h5
+        style={{
+          textOrientation: 'upright',
+          writingMode: 'vertical-rl',
+          margin: '0',
+          color: 'var(--gold-color)',
+          textAlign: 'center',
+        }}
+      >
+        SOUNDBOARD
+      </h5>
+      <div style={{ display: 'flex', flexDirection: 'row', flexWrap: 'wrap', justifyContent: 'center', margin: '0' }}>
+        <SoundboardButton text={'thunder'} icon={ThunderstormIcon} color={'#4a4a8a'} />
+        <SoundboardButton text={'scream'} icon={RecordVoiceOverIcon} color={'#8a2a2a'} />
+        <SoundboardButton text={'door open'} icon={DoorFrontIcon} color={'#7a5a1a'} />
+        <SoundboardButton text={'door shut'} icon={MeetingRoomIcon} color={'#5a4a1a'} />
+        <SoundboardButton text={'battle'} icon={GpsFixedIcon} color={'#7a0000'} />
+        <SoundboardButton text={'explosion'} icon={LocalFireDepartmentIcon} color={'#a04000'} />
+      </div>
+    </div>
+  );
+}

--- a/apps/rpg-maestro-ui/src/app/maestro-ui/soundboard/soundboard.tsx
+++ b/apps/rpg-maestro-ui/src/app/maestro-ui/soundboard/soundboard.tsx
@@ -1,13 +1,42 @@
 import React from 'react';
+import { SvgIconComponent } from '@mui/icons-material';
+import { Track } from '@rpg-maestro/rpg-maestro-api-contract';
 import { SoundboardButton } from './soundboard-button';
+import { Color } from '../tracks-table/quick-tag-selection';
 import ThunderstormIcon from '@mui/icons-material/Thunderstorm';
 import RecordVoiceOverIcon from '@mui/icons-material/RecordVoiceOver';
 import DoorFrontIcon from '@mui/icons-material/DoorFront';
 import MeetingRoomIcon from '@mui/icons-material/MeetingRoom';
 import GpsFixedIcon from '@mui/icons-material/GpsFixed';
 import LocalFireDepartmentIcon from '@mui/icons-material/LocalFireDepartment';
+import VolumeUpIcon from '@mui/icons-material/VolumeUp';
 
-export function Soundboard() {
+const ICON_MAP: Record<string, SvgIconComponent> = {
+  thunder: ThunderstormIcon,
+  scream: RecordVoiceOverIcon,
+  'door open': DoorFrontIcon,
+  'door shut': MeetingRoomIcon,
+  battle: GpsFixedIcon,
+  explosion: LocalFireDepartmentIcon,
+};
+
+const COLOR_MAP: Record<string, Color> = {
+  thunder: '#4a4a8a',
+  scream: '#8a2a2a',
+  'door open': '#7a5a1a',
+  'door shut': '#5a4a1a',
+  battle: '#7a0000',
+  explosion: '#a04000',
+};
+
+const DEFAULT_COLOR: Color = '#888888';
+
+interface SoundboardProps {
+  tracks: Track[];
+  onPlay: (trackId: string) => void;
+}
+
+export function Soundboard({ tracks, onPlay }: SoundboardProps) {
   return (
     <div style={{ display: 'inline-flex', justifyContent: 'flex-start', width: '250px' }}>
       <h5
@@ -22,12 +51,15 @@ export function Soundboard() {
         SOUNDBOARD
       </h5>
       <div style={{ display: 'flex', flexDirection: 'row', flexWrap: 'wrap', justifyContent: 'center', margin: '0' }}>
-        <SoundboardButton text={'thunder'} icon={ThunderstormIcon} color={'#4a4a8a'} />
-        <SoundboardButton text={'scream'} icon={RecordVoiceOverIcon} color={'#8a2a2a'} />
-        <SoundboardButton text={'door open'} icon={DoorFrontIcon} color={'#7a5a1a'} />
-        <SoundboardButton text={'door shut'} icon={MeetingRoomIcon} color={'#5a4a1a'} />
-        <SoundboardButton text={'battle'} icon={GpsFixedIcon} color={'#7a0000'} />
-        <SoundboardButton text={'explosion'} icon={LocalFireDepartmentIcon} color={'#a04000'} />
+        {tracks.map((track) => (
+          <SoundboardButton
+            key={track.id}
+            text={track.name}
+            icon={ICON_MAP[track.name.toLowerCase()] ?? VolumeUpIcon}
+            color={COLOR_MAP[track.name.toLowerCase()] ?? DEFAULT_COLOR}
+            onPlay={() => onPlay(track.id)}
+          />
+        ))}
       </div>
     </div>
   );

--- a/apps/rpg-maestro-ui/src/app/maestro-ui/tracks-table/tracks-table.tsx
+++ b/apps/rpg-maestro-ui/src/app/maestro-ui/tracks-table/tracks-table.tsx
@@ -14,6 +14,7 @@ const paginationModel = { page: 0, pageSize: 10 };
 export interface TrackFilters {
   trackIdToFilterOn?: string;
   tagsToFilterOn?: string[];
+  excludeTags?: string[];
 }
 
 export interface TracksTableProps {
@@ -142,6 +143,9 @@ export function TracksTable(props: TracksTableProps) {
 
 export function filter(tracks: Track[], filters: TrackFilters): Track[] {
   let filteredTracks = [...tracks];
+  if (filters.excludeTags?.length) {
+    filteredTracks = filteredTracks.filter((x) => !filters.excludeTags!.some((tag) => x.tags.includes(tag)));
+  }
   if (filters.trackIdToFilterOn) {
     const foundTrack = filteredTracks.find((x) => x.id === filters.trackIdToFilterOn);
     return foundTrack ? [foundTrack] : [];

--- a/apps/rpg-maestro/src/app/AuthenticatedMaestroController.ts
+++ b/apps/rpg-maestro/src/app/AuthenticatedMaestroController.ts
@@ -136,6 +136,17 @@ export class AuthenticatedMaestroController {
     return this.trackService.getAll(sessionId);
   }
 
+  @Get('/maestro/sessions/:sessionId/soundboard-tracks')
+  @Roles([Role.MAESTRO, Role.MINSTREL])
+  async getSoundboardTracks(
+    @Request() req: { user: AuthenticatedUser },
+    @Param('sessionId') sessionId: string
+  ): Promise<Track[]> {
+    await this.checkAccessOnSession(req.user, sessionId);
+    const all = await this.trackService.getAll(sessionId);
+    return all.filter((t) => t.tags.includes('soundboard'));
+  }
+
   @Put('/maestro/sessions/:sessionId/playing-tracks')
   @Roles([Role.MAESTRO, Role.MINSTREL])
   async changeCurrentTrack(


### PR DESCRIPTION
Adds a Soundboard component to the maestro page with 6 one-shot sound effect buttons (thunder, scream, door open, door shut, battle, explosion) visually matching the existing quick tags style. Sounds are mocked with a placeholder MP3. Includes a Storybook story under Maestro/Soundboard.