### PR TITLE
feat: soundboard short effect track overlay

### DIFF
--- a/apps/rpg-maestro-ui-e2e/src/onboarding.spec.ts
+++ b/apps/rpg-maestro-ui-e2e/src/onboarding.spec.ts
@@ -31,7 +31,7 @@ test('a new User can become a Maestro and have his own session', async ({ page }
 
   await test.step('a track should be playing', async () => {
     await expect(page.getByText('No tracks selected to play')).toBeHidden();
-    const audio = page.locator('audio');
+    const audio = page.locator('audio').first();
     // Wait until the audio element is ready and has a source
     await expect.poll(async () => {
       return await audio.evaluate((el: HTMLAudioElement) => el.readyState >= 2 && el.src !== '');

--- a/apps/rpg-maestro-ui/src/app/maestro-ui/maestro-api.ts
+++ b/apps/rpg-maestro-ui/src/app/maestro-ui/maestro-api.ts
@@ -97,6 +97,17 @@ export const setTrackToPlay = async (
             rawSerialized.currentTrack.playTimestamp,
             rawSerialized.currentTrack.trackStartTime
           ),
+      shortEffectTrack: !rawSerialized.shortEffectTrack
+        ? null
+        : new PlayingTrack(
+            rawSerialized.shortEffectTrack.id,
+            rawSerialized.shortEffectTrack.name,
+            rawSerialized.shortEffectTrack.url,
+            rawSerialized.shortEffectTrack.duration,
+            rawSerialized.shortEffectTrack.isPaused,
+            rawSerialized.shortEffectTrack.playTimestamp,
+            rawSerialized.shortEffectTrack.trackStartTime
+          ),
     };
   } catch (error) {
     if ((error as DOMException).name === 'AbortError') {

--- a/apps/rpg-maestro-ui/src/app/maestro-ui/maestro-api.ts
+++ b/apps/rpg-maestro-ui/src/app/maestro-ui/maestro-api.ts
@@ -244,7 +244,7 @@ export const getMaestroInfos = async (): Promise<User> => {
 export const importCollectionToSession = async (sessionId: string, collectionId: string): Promise<Track[]> => {
   try {
     const response = await authenticatedFetch(
-      `${rpgmaestroapiurl}/maestro/sessions/${sessionId}/tracks/from-collection/${collectionId}`,
+      `${rpgMaestroApiUrl}/maestro/sessions/${sessionId}/tracks/from-collection/${collectionId}`,
       {
         method: 'POST',
         credentials: 'include',

--- a/apps/rpg-maestro-ui/src/app/maestro-ui/maestro-audio-player/maestro-audio-player.tsx
+++ b/apps/rpg-maestro-ui/src/app/maestro-ui/maestro-audio-player/maestro-audio-player.tsx
@@ -2,7 +2,7 @@ import { PlayingTrack, SessionPlayingTracks, TrackToPlay } from '@rpg-maestro/rp
 import AudioPlayer from 'react-h5-audio-player';
 import H5AudioPlayer from 'react-h5-audio-player';
 import React, { forwardRef, Ref, useCallback, useEffect, useImperativeHandle, useRef, useState } from 'react';
-import { resyncCurrentTrackIfNeeded } from '../../track-sync/track-sync';
+import { resyncIfNeeded } from '../../track-sync/track-sync';
 import { displayError } from '../../error-utils';
 import './maestro-audio-player.css';
 import { AbortedRequestError } from '../maestro-api';
@@ -119,13 +119,14 @@ export const MaestroAudioPlayer = forwardRef((props: MaestroAudioPlayerProps, re
       return Promise.resolve();
     }
     const requestFunc = () =>
-      resyncCurrentTrackIfNeeded(
+      resyncIfNeeded(
         sessionId,
         audioPlayer.current?.audio?.current?.currentTime ?? null,
-        currentTrack
-      ).then((newerServerTrack) => {
-        if (newerServerTrack !== 'AbortedRequestError') {
-          return resyncCurrentTrackOnUi(newerServerTrack);
+        currentTrack,
+        null,
+      ).then((syncResult) => {
+        if (syncResult !== 'AbortedRequestError') {
+          return resyncCurrentTrackOnUi(syncResult.currentTrack);
         }
         return Promise.resolve();
       });

--- a/apps/rpg-maestro-ui/src/app/maestro-ui/maestro-soundboard.tsx
+++ b/apps/rpg-maestro-ui/src/app/maestro-ui/maestro-soundboard.tsx
@@ -77,6 +77,17 @@ function MaestroSoundboardComponent() {
     }
     dispatchTrackWasManuallyChanged(changedTracks);
   };
+
+  const requestPlaySoundEffect = async (trackId: string) => {
+    try {
+      const result = await setTrackToPlay(sessionId, { shortEffectTrack: { trackId } });
+      if (result === 'AbortedRequestError') {
+        return;
+      }
+    } catch (err) {
+      return Promise.reject(err);
+    }
+  };
   const requestEditTrackToPlay = async (
     trackToPlay: TrackToPlay
   ): Promise<SessionPlayingTracks | AbortedRequestError> => {
@@ -170,7 +181,7 @@ function MaestroSoundboardComponent() {
       <div style={{ display: 'flex', justifyContent: 'space-around', alignItems: 'center', gap: '1rem' }}>
         <div style={{ display: 'flex', flexDirection: 'column', gap: '1rem' }}>
         {soundboardTracks && soundboardTracks.length > 0 && (
-          <Soundboard tracks={soundboardTracks} onPlay={requestSetTrackToPlay} />
+          <Soundboard tracks={soundboardTracks} onPlay={requestPlaySoundEffect} />
         )}
         <div style={{ display: 'inline-flex', justifyContent: 'flex-start', width: '250px' }}>
           <h5

--- a/apps/rpg-maestro-ui/src/app/maestro-ui/maestro-soundboard.tsx
+++ b/apps/rpg-maestro-ui/src/app/maestro-ui/maestro-soundboard.tsx
@@ -37,6 +37,7 @@ function MaestroSoundboardComponent() {
     throw new Error('no session found in URL');
   }
   const maestroAudioPlayerChildRef = useRef<MaestroAudioPlayerRef>(null);
+  const effectAudioRef = useRef<HTMLAudioElement>(null);
   const dispatchTrackWasManuallyChanged = (newTracks: SessionPlayingTracks): void => {
     maestroAudioPlayerChildRef?.current?.dispatchTrackWasManuallyChanged(newTracks);
   };
@@ -83,6 +84,11 @@ function MaestroSoundboardComponent() {
       const result = await setTrackToPlay(sessionId, { shortEffectTrack: { trackId } });
       if (result === 'AbortedRequestError') {
         return;
+      }
+      if (result.shortEffectTrack && effectAudioRef.current) {
+        effectAudioRef.current.src = result.shortEffectTrack.url;
+        effectAudioRef.current.currentTime = 0;
+        await effectAudioRef.current.play();
       }
     } catch (err) {
       return Promise.reject(err);
@@ -267,6 +273,7 @@ function MaestroSoundboardComponent() {
           onRefreshRequested={refreshTracks}
         />
       </div>
+      <audio ref={effectAudioRef} style={{ display: 'none' }} />
       <ToastContainer limit={5} />
     </div>
   );

--- a/apps/rpg-maestro-ui/src/app/maestro-ui/maestro-soundboard.tsx
+++ b/apps/rpg-maestro-ui/src/app/maestro-ui/maestro-soundboard.tsx
@@ -174,11 +174,6 @@ function MaestroSoundboardComponent() {
               text={'Manage your tracks'}
               materialUiIcon={LyricsTwoTone}
             />
-            <TextLinkWithIconWrapper
-              link={`/maestro/track-collections?sessionId=${sessionId}`}
-              text={'Track collections'}
-              materialUiIcon={CollectionsBookmarkTwoTone}
-            />
           </div>
         ) : (
           ''

--- a/apps/rpg-maestro-ui/src/app/maestro-ui/soundboard/soundboard-button.spec.tsx
+++ b/apps/rpg-maestro-ui/src/app/maestro-ui/soundboard/soundboard-button.spec.tsx
@@ -1,0 +1,31 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { vi } from 'vitest';
+import { SoundboardButton } from './soundboard-button';
+import ThunderstormIcon from '@mui/icons-material/Thunderstorm';
+
+describe('SoundboardButton', () => {
+  it('renders the text and icon', () => {
+    render(<SoundboardButton text="thunder" icon={ThunderstormIcon} color="#4a4a8a" onPlay={vi.fn()} />);
+
+    expect(screen.getByText('thunder')).toBeDefined();
+    expect(screen.getByTestId('ThunderstormIcon')).toBeDefined();
+  });
+
+  it('calls onPlay when clicked', async () => {
+    const onPlay = vi.fn();
+
+    render(<SoundboardButton text="thunder" icon={ThunderstormIcon} color="#4a4a8a" onPlay={onPlay} />);
+
+    await userEvent.click(screen.getByRole('button'));
+
+    expect(onPlay).toHaveBeenCalledOnce();
+  });
+
+  it('applies the given color', () => {
+    render(<SoundboardButton text="thunder" icon={ThunderstormIcon} color="#ff0000" onPlay={vi.fn()} />);
+
+    const button = screen.getByRole('button');
+    expect(button.style.color).toBe('rgb(255, 0, 0)');
+  });
+});

--- a/apps/rpg-maestro-ui/src/app/maestro-ui/soundboard/soundboard.spec.tsx
+++ b/apps/rpg-maestro-ui/src/app/maestro-ui/soundboard/soundboard.spec.tsx
@@ -2,30 +2,24 @@ import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { vi } from 'vitest';
 import { Soundboard } from './soundboard';
+import { Track } from '@rpg-maestro/rpg-maestro-api-contract';
 
-const mockTracks = [
-  {
-    id: 'track-thunder',
-    name: 'thunder',
+function mockTrack(overrides: Partial<Track> & { id: string; name: string }): Track {
+  return {
     tags: ['soundboard'],
-    url: 'http://localhost/thunder.mp3',
+    url: 'http://localhost/sound.mp3',
     duration: 5,
     sessionId: 'session-1',
     created_at: 0,
     updated_at: 0,
     source: { origin_media: 'remote', origin_url: '', origin_name: '' },
-  },
-  {
-    id: 'track-explosion',
-    name: 'explosion',
-    tags: ['soundboard'],
-    url: 'http://localhost/explosion.mp3',
-    duration: 4,
-    sessionId: 'session-1',
-    created_at: 0,
-    updated_at: 0,
-    source: { origin_media: 'remote', origin_url: '', origin_name: '' },
-  },
+    ...overrides,
+  };
+}
+
+const mockTracks = [
+  mockTrack({ id: 'track-thunder', name: 'thunder' }),
+  mockTrack({ id: 'track-explosion', name: 'explosion' }),
 ];
 
 describe('Soundboard', () => {
@@ -49,5 +43,50 @@ describe('Soundboard', () => {
 
     expect(onPlay).toHaveBeenCalledOnce();
     expect(onPlay).toHaveBeenCalledWith('track-explosion');
+  });
+
+  it('renders a button for each track', () => {
+    const allKnownTracks = [
+      mockTrack({ id: '1', name: 'thunder' }),
+      mockTrack({ id: '2', name: 'scream' }),
+      mockTrack({ id: '3', name: 'door open' }),
+      mockTrack({ id: '4', name: 'door shut' }),
+      mockTrack({ id: '5', name: 'battle' }),
+      mockTrack({ id: '6', name: 'explosion' }),
+    ];
+
+    render(<Soundboard tracks={allKnownTracks} onPlay={vi.fn()} />);
+
+    for (const track of allKnownTracks) {
+      expect(screen.getByText(track.name)).toBeDefined();
+    }
+    expect(screen.getAllByRole('button')).toHaveLength(6);
+  });
+
+  it('renders unknown tracks with a fallback button', () => {
+    const unknownTrack = [mockTrack({ id: 'unknown-1', name: 'alien noise' })];
+
+    render(<Soundboard tracks={unknownTrack} onPlay={vi.fn()} />);
+
+    expect(screen.getByText('alien noise')).toBeDefined();
+    expect(screen.getAllByRole('button')).toHaveLength(1);
+  });
+
+  it('renders nothing when tracks array is empty', () => {
+    const { container } = render(<Soundboard tracks={[]} onPlay={vi.fn()} />);
+
+    expect(screen.queryAllByRole('button')).toHaveLength(0);
+    expect(container.querySelector('h5')?.textContent).toBe('SOUNDBOARD');
+  });
+
+  it('does not call onPlay for other buttons when one is clicked', async () => {
+    const onPlay = vi.fn();
+
+    render(<Soundboard tracks={mockTracks} onPlay={onPlay} />);
+
+    await userEvent.click(screen.getByText('thunder'));
+
+    expect(onPlay).toHaveBeenCalledOnce();
+    expect(onPlay).not.toHaveBeenCalledWith('track-explosion');
   });
 });

--- a/apps/rpg-maestro-ui/src/app/players-ui/players-ui.tsx
+++ b/apps/rpg-maestro-ui/src/app/players-ui/players-ui.tsx
@@ -3,7 +3,7 @@ import H5AudioPlayer from 'react-h5-audio-player';
 import { ToastContainer } from 'react-toastify';
 import React, { LegacyRef, useEffect, useRef, useState } from 'react';
 import styled from 'styled-components';
-import { resyncCurrentTrackIfNeeded } from '../track-sync/track-sync';
+import { resyncIfNeeded } from '../track-sync/track-sync';
 import { displayError } from '../error-utils';
 import { PlayingTrack } from '@rpg-maestro/rpg-maestro-api-contract';
 import GithubSourceCodeLink from '../ui-components/github-source-code-link/github-source-code-link';
@@ -86,25 +86,31 @@ export const SYNC_TRACK_INTERVAL_MS = 1000;
 
 export function PlayersUi() {
   const [currentTrack, setCurrentTrack] = useState<PlayingTrack | null>(null);
+  const [shortEffectTrack, setShortEffectTrack] = useState<PlayingTrack | null>(null);
   const audioPlayer = useRef<H5AudioPlayer>();
+  const effectAudioRef = useRef<HTMLAudioElement>(null);
   const sessionId = useParams().sessionId ?? '';
   if (sessionId === '') {
     displayError('no session found in URL (it should be https://{URL}/session/{sessionId})');
   }
 
   useEffect(() => {
-    async function resyncCurrentTrackOnUi() {
-      const newerServerTrack = await resyncCurrentTrackIfNeeded(
+    async function resyncOnUi() {
+      const syncResult = await resyncIfNeeded(
         sessionId,
         audioPlayer.current?.audio?.current?.currentTime ?? null,
-        currentTrack
+        currentTrack,
+        shortEffectTrack,
       );
-      if (newerServerTrack && newerServerTrack !== 'AbortedRequestError') {
+      if (syncResult === 'AbortedRequestError') {
+        return;
+      }
+
+      // Handle current track sync
+      const newerServerTrack = syncResult.currentTrack;
+      if (newerServerTrack) {
         console.info('synchronizing track');
         setCurrentTrack(newerServerTrack);
-        if (!newerServerTrack) {
-          throw new Error('Current track is not defined');
-        }
         if (audioPlayer.current?.audio?.current) {
           if (audioPlayer.current.audio.current.src !== newerServerTrack.url) {
             audioPlayer.current.audio.current.src = newerServerTrack.url;
@@ -113,10 +119,8 @@ export function PlayersUi() {
           const currentPlayTime = newerServerTrack.getCurrentPlayTime();
           audioPlayer.current.audio.current.currentTime = currentPlayTime / 1000;
           if (newerServerTrack.isPaused) {
-            // paused
             audioPlayer.current.audio.current.pause();
           } else {
-            // playing
             try {
               await audioPlayer.current.audio.current.play();
             } catch (error) {
@@ -134,14 +138,28 @@ export function PlayersUi() {
           console.warn('audio player not available yet');
         }
       }
+
+      // Handle short effect track
+      const newEffect = syncResult.shortEffectTrack;
+      if (newEffect && effectAudioRef.current) {
+        console.info('playing short effect track:', newEffect.name);
+        setShortEffectTrack(newEffect);
+        effectAudioRef.current.src = newEffect.url;
+        effectAudioRef.current.currentTime = 0;
+        try {
+          await effectAudioRef.current.play();
+        } catch (error) {
+          console.error('Failed to play short effect track:', error);
+        }
+      }
     }
 
-    resyncCurrentTrackOnUi();
+    resyncOnUi();
     const id = setInterval(() => {
-      resyncCurrentTrackOnUi();
+      resyncOnUi();
     }, SYNC_TRACK_INTERVAL_MS);
     return () => clearInterval(id);
-  }, [currentTrack, sessionId]);
+  }, [currentTrack, shortEffectTrack, sessionId]);
 
   return (
     <Container>
@@ -194,6 +212,7 @@ export function PlayersUi() {
         }}
       />
 
+      <audio ref={effectAudioRef} style={{ display: 'none' }} />
       <GithubSourceCodeLink />
       <ToastContainer limit={5} />
     </Container>

--- a/apps/rpg-maestro-ui/src/app/track-sync/track-sync.ts
+++ b/apps/rpg-maestro-ui/src/app/track-sync/track-sync.ts
@@ -1,37 +1,69 @@
-import { getCurrentTrack } from '../tracks-api';
-import { PlayingTrack } from '@rpg-maestro/rpg-maestro-api-contract';
+import { getSessionPlayingTracks } from '../tracks-api';
+import { PlayingTrack, SessionPlayingTracks } from '@rpg-maestro/rpg-maestro-api-contract';
 import { AbortedRequestError } from '../maestro-ui/maestro-api';
+
+export interface SyncResult {
+  currentTrack: PlayingTrack | null;
+  shortEffectTrack: PlayingTrack | null;
+}
 
 /**
  *
  * @param sessionId
  * @param currentTrackPlayTime the requested play time of the track
  * @param currentTrack the current track in the browser
- * @param options
+ * @param localShortEffectTrack the current short effect track in the browser
  */
-export const resyncCurrentTrackIfNeeded = async (
+export const resyncIfNeeded = async (
   sessionId: string,
   currentTrackPlayTime: number | null,
   currentTrack: PlayingTrack | null,
-): Promise<PlayingTrack | null | AbortedRequestError> => {
-  const optServerTrack = await getCurrentTrack(sessionId);
-  if(optServerTrack==='AbortedRequestError'){
-    return optServerTrack;
+  localShortEffectTrack: PlayingTrack | null,
+): Promise<SyncResult | AbortedRequestError> => {
+  const serverState = await getSessionPlayingTracks(sessionId);
+  if (serverState === 'AbortedRequestError') {
+    return serverState;
   }
-  if (!optServerTrack) {
+
+  const newCurrentTrack = resolveCurrentTrackSync(currentTrackPlayTime, currentTrack, serverState);
+  const newShortEffect = resolveShortEffectSync(localShortEffectTrack, serverState.shortEffectTrack);
+
+  return { currentTrack: newCurrentTrack, shortEffectTrack: newShortEffect };
+};
+
+function resolveCurrentTrackSync(
+  currentTrackPlayTime: number | null,
+  currentTrack: PlayingTrack | null,
+  serverState: SessionPlayingTracks,
+): PlayingTrack | null {
+  const serverTrack = serverState.currentTrack;
+  if (!serverTrack) {
     return null;
   }
   if (
     currentTrackPlayTime === null ||
     currentTrackPlayTime === undefined ||
     !currentTrack ||
-    isCurrentTrackOutOfDate(currentTrack, optServerTrack) ||
-    isCurrentTrackTooMuchDesynchronizedFromServer(currentTrackPlayTime * 1000, optServerTrack)
+    isCurrentTrackOutOfDate(currentTrack, serverTrack) ||
+    isCurrentTrackTooMuchDesynchronizedFromServer(currentTrackPlayTime * 1000, serverTrack)
   ) {
-    return optServerTrack;
+    return serverTrack;
   }
   return null;
-};
+}
+
+function resolveShortEffectSync(
+  localEffectTrack: PlayingTrack | null,
+  serverEffectTrack: PlayingTrack | null,
+): PlayingTrack | null {
+  if (!serverEffectTrack) {
+    return null;
+  }
+  if (!localEffectTrack || localEffectTrack.playTimestamp !== serverEffectTrack.playTimestamp) {
+    return serverEffectTrack;
+  }
+  return null;
+}
 
 export const isCurrentTrackTooMuchDesynchronizedFromServer = (
   currentTrackPlayTime: number,

--- a/apps/rpg-maestro-ui/src/app/tracks-api.ts
+++ b/apps/rpg-maestro-ui/src/app/tracks-api.ts
@@ -10,11 +10,26 @@ interface OngoingRequest {
   startTimeMs: number;
 }
 
+function deserializePlayingTrack(track: PlayingTrack): PlayingTrack {
+  return new PlayingTrack(
+    track.id,
+    track.name,
+    track.url,
+    track.duration,
+    track.isPaused,
+    track.playTimestamp,
+    track.trackStartTime
+  );
+}
+
 let ongoingRequest: OngoingRequest | null = null;
-export const getCurrentTrack = async (sessionId: string, options?: {manuallyRequested?: boolean}): Promise<PlayingTrack | null | AbortedRequestError> => {
+export const getSessionPlayingTracks = async (
+  sessionId: string,
+  options?: { manuallyRequested?: boolean }
+): Promise<SessionPlayingTracks | AbortedRequestError> => {
   // Abort previous request if any
   if (ongoingRequest) {
-    if(options?.manuallyRequested){
+    if (options?.manuallyRequested) {
       ongoingRequest.abortController.abort();
     } else {
       const ongoingRequestDuration = Date.now() - ongoingRequest.startTimeMs;
@@ -33,21 +48,12 @@ export const getCurrentTrack = async (sessionId: string, options?: {manuallyRequ
     });
     if (response.ok) {
       const res = (await response.json()) as SessionPlayingTracks;
-      const track = res.currentTrack;
       ongoingRequest = null;
-      if (track != null) {
-        return new PlayingTrack(
-          track.id,
-          track.name,
-          track.url,
-          track.duration,
-          track.isPaused,
-          track.playTimestamp,
-          track.trackStartTime
-        );
-      } else {
-        return null;
-      }
+      return {
+        sessionId: res.sessionId,
+        currentTrack: res.currentTrack ? deserializePlayingTrack(res.currentTrack) : null,
+        shortEffectTrack: res.shortEffectTrack ? deserializePlayingTrack(res.shortEffectTrack) : null,
+      };
     } else {
       console.error(response.status, response.statusText);
       console.error(response);
@@ -60,6 +66,6 @@ export const getCurrentTrack = async (sessionId: string, options?: {manuallyRequ
     }
     console.error(error);
     displayError(`Fetch current/tracks error: ${error}`);
-    return null;
+    return { sessionId, currentTrack: null, shortEffectTrack: null };
   }
 };

--- a/apps/rpg-maestro/examples/SetupDevEnvironment.http
+++ b/apps/rpg-maestro/examples/SetupDevEnvironment.http
@@ -89,3 +89,64 @@ Authorization: Bearer {{an_admin_user.token}}
   "directoryUrl": "https://rpgmaestro.app/public/musics",
   "tags": ["combat", "travel"]
 }
+
+###
+### Create Soundboard track collection
+POST http://localhost:3000/track-collections
+Content-Type: application/json
+Authorization: Bearer {{an_admin_user.token}}
+
+{
+  "id": "soundboard-collection",
+  "name": "Soundboard",
+  "description": "Quick sound effects for the soundboard",
+  "tracks": [
+    {
+      "name": "Sword Clash",
+      "tags": ["soundboard"],
+      "url": "https://cdn.freesound.org/previews/763/763587_10152894-lq.mp3",
+      "source": { "origin_media": "freesound", "origin_url": "https://freesound.org/s/763587/", "origin_name": "Sword Clash" }
+    },
+    {
+      "name": "Thunder Crack",
+      "tags": ["soundboard"],
+      "url": "https://cdn.freesound.org/previews/763/763587_10152894-lq.mp3",
+      "source": { "origin_media": "freesound", "origin_url": "https://freesound.org/s/763587/", "origin_name": "Thunder Crack" }
+    },
+    {
+      "name": "Door Creak",
+      "tags": ["soundboard"],
+      "url": "https://cdn.freesound.org/previews/763/763587_10152894-lq.mp3",
+      "source": { "origin_media": "freesound", "origin_url": "https://freesound.org/s/763587/", "origin_name": "Door Creak" }
+    },
+    {
+      "name": "Coin Pouch",
+      "tags": ["soundboard"],
+      "url": "https://cdn.freesound.org/previews/763/763587_10152894-lq.mp3",
+      "source": { "origin_media": "freesound", "origin_url": "https://freesound.org/s/763587/", "origin_name": "Coin Pouch" }
+    },
+    {
+      "name": "Arrow Whoosh",
+      "tags": ["soundboard"],
+      "url": "https://cdn.freesound.org/previews/763/763587_10152894-lq.mp3",
+      "source": { "origin_media": "freesound", "origin_url": "https://freesound.org/s/763587/", "origin_name": "Arrow Whoosh" }
+    }
+  ]
+}
+
+> {%
+  client.test("Request executed successfully", function() {
+    client.assert(response.status === 201, "response status code was: " + response.status);
+  });
+%}
+
+###
+### Import Soundboard collection into the session
+POST http://localhost:3000/maestro/sessions/{{session_id}}/tracks/from-collection/soundboard-collection
+Authorization: Bearer {{an_admin_user.token}}
+
+> {%
+  client.test("Request executed successfully", function() {
+    client.assert(response.status === 201, "response status code was: " + response.status);
+  });
+%}

--- a/apps/rpg-maestro/src/app/infrastructure/persistence/firestore/FirestoreTracksDatabase.ts
+++ b/apps/rpg-maestro/src/app/infrastructure/persistence/firestore/FirestoreTracksDatabase.ts
@@ -20,6 +20,7 @@ export class FirestoreTracksDatabase implements TracksDatabase {
     const newSession: SessionPlayingTrackEntity = {
       id: sessionId,
       currentTrack: null,
+      shortEffectTrack: null,
     };
     await this.db.collection(RPG_MAESTRO_SESSIONS_DB).doc(sessionId).set(newSession);
     return await Promise.resolve();
@@ -50,17 +51,25 @@ export class FirestoreTracksDatabase implements TracksDatabase {
   }
 
   async upsertCurrentTrack(sessionId: string, playingTrack: PlayingTrack): Promise<SessionPlayingTracks> {
+    const existing = await this.getSession(sessionId);
     const sessionEntity: SessionPlayingTrackEntity = {
       id: sessionId,
-      currentTrack: {
-        id: playingTrack.id,
-        name: playingTrack.name,
-        url: playingTrack.url,
-        duration: playingTrack.duration,
-        isPaused: playingTrack.isPaused,
-        playTimestamp: playingTrack.playTimestamp,
-        trackStartTime: playingTrack.trackStartTime,
-      },
+      currentTrack: playingTrackToEntity(playingTrack),
+      shortEffectTrack: existing?.shortEffectTrack ? playingTrackToEntity(existing.shortEffectTrack) : null,
+    };
+    await this.db
+      .collection(RPG_MAESTRO_SESSIONS_DB)
+      .doc(sessionId)
+      .set(sessionEntity);
+    return entityToSession(sessionEntity);
+  }
+
+  async upsertShortEffectTrack(sessionId: string, playingTrack: PlayingTrack): Promise<SessionPlayingTracks> {
+    const existing = await this.getSession(sessionId);
+    const sessionEntity: SessionPlayingTrackEntity = {
+      id: sessionId,
+      currentTrack: existing?.currentTrack ? playingTrackToEntity(existing.currentTrack) : null,
+      shortEffectTrack: playingTrackToEntity(playingTrack),
     };
     await this.db
       .collection(RPG_MAESTRO_SESSIONS_DB)
@@ -88,6 +97,7 @@ export class FirestoreTracksDatabase implements TracksDatabase {
 interface SessionPlayingTrackEntity {
   id: string;
   currentTrack: PlayingTrackEntity | null;
+  shortEffectTrack: PlayingTrackEntity | null;
 }
 
 interface PlayingTrackEntity {
@@ -101,18 +111,34 @@ interface PlayingTrackEntity {
   trackStartTime: number;
 }
 
-function entityToSession(entity: SessionPlayingTrackEntity): SessionPlayingTracks{
-  const session: SessionPlayingTracks = {
+function playingTrackToEntity(track: PlayingTrack): PlayingTrackEntity {
+  return {
+    id: track.id,
+    name: track.name,
+    url: track.url,
+    duration: track.duration,
+    isPaused: track.isPaused,
+    playTimestamp: track.playTimestamp,
+    trackStartTime: track.trackStartTime,
+  };
+}
+
+function entityToPlayingTrack(entity: PlayingTrackEntity): PlayingTrack {
+  return new PlayingTrack(
+    entity.id,
+    entity.name,
+    entity.url,
+    entity.duration,
+    entity.isPaused,
+    entity.playTimestamp,
+    entity.trackStartTime
+  );
+}
+
+function entityToSession(entity: SessionPlayingTrackEntity): SessionPlayingTracks {
+  return {
     sessionId: entity.id,
-    currentTrack: entity.currentTrack ? new PlayingTrack(
-      entity.currentTrack.id,
-      entity.currentTrack.name,
-      entity.currentTrack.url,
-      entity.currentTrack.duration,
-      entity.currentTrack.isPaused,
-      entity.currentTrack.playTimestamp,
-      entity.currentTrack.trackStartTime
-    ) : null,
-  }
-  return session;
+    currentTrack: entity.currentTrack ? entityToPlayingTrack(entity.currentTrack) : null,
+    shortEffectTrack: entity.shortEffectTrack ? entityToPlayingTrack(entity.shortEffectTrack) : null,
+  };
 }

--- a/apps/rpg-maestro/src/app/infrastructure/persistence/in-memory/InMemoryTracksDatabase.ts
+++ b/apps/rpg-maestro/src/app/infrastructure/persistence/in-memory/InMemoryTracksDatabase.ts
@@ -6,7 +6,7 @@ export class InMemoryTracksDatabase implements TracksDatabase {
   sessionDatabase: { [name: SessionID]: SessionPlayingTracks } = {};
 
   createSession(sessionId: SessionID): Promise<void> {
-    this.sessionDatabase[sessionId] = { sessionId: sessionId, currentTrack: null };
+    this.sessionDatabase[sessionId] = { sessionId: sessionId, currentTrack: null, shortEffectTrack: null };
     return Promise.resolve();
   }
 
@@ -18,6 +18,7 @@ export class InMemoryTracksDatabase implements TracksDatabase {
     return Promise.resolve({
       sessionId: sessionId,
       currentTrack: this.sessionDatabase[sessionId]?.currentTrack,
+      shortEffectTrack: this.sessionDatabase[sessionId]?.shortEffectTrack ?? null,
     });
   }
 
@@ -33,9 +34,18 @@ export class InMemoryTracksDatabase implements TracksDatabase {
 
   upsertCurrentTrack(sessionId: string, playingTrack: PlayingTrack): Promise<SessionPlayingTracks> {
     if (!this.sessionDatabase[sessionId]) {
-      this.sessionDatabase[sessionId] = { sessionId: sessionId, currentTrack: playingTrack };
+      this.sessionDatabase[sessionId] = { sessionId: sessionId, currentTrack: playingTrack, shortEffectTrack: null };
     } else {
       this.sessionDatabase[sessionId].currentTrack = playingTrack;
+    }
+    return Promise.resolve(this.sessionDatabase[sessionId]);
+  }
+
+  upsertShortEffectTrack(sessionId: string, playingTrack: PlayingTrack): Promise<SessionPlayingTracks> {
+    if (!this.sessionDatabase[sessionId]) {
+      this.sessionDatabase[sessionId] = { sessionId: sessionId, currentTrack: null, shortEffectTrack: playingTrack };
+    } else {
+      this.sessionDatabase[sessionId].shortEffectTrack = playingTrack;
     }
     return Promise.resolve(this.sessionDatabase[sessionId]);
   }

--- a/apps/rpg-maestro/src/app/maestro-api/ManageCurrentlyPlayingTracks.ts
+++ b/apps/rpg-maestro/src/app/maestro-api/ManageCurrentlyPlayingTracks.ts
@@ -26,6 +26,24 @@ export class ManageCurrentlyPlayingTracks {
       throw new Error('when changeSessionPlayingTracks, request is required');
     }
 
+    if (changeSessionPlayingTracksRequest.shortEffectTrack) {
+      const track = await this.database.getTrack(changeSessionPlayingTracksRequest.shortEffectTrack.trackId);
+      const playingTrack = new PlayingTrack(
+        track.id,
+        track.name,
+        track.url,
+        track.duration,
+        false,
+        Date.now(),
+        0
+      );
+      return this.sessionsService.upsertShortEffectTrack(sessionId, playingTrack);
+    }
+
+    if (!changeSessionPlayingTracksRequest.currentTrack) {
+      throw new Error('when changeSessionPlayingTracks, either currentTrack or shortEffectTrack is required');
+    }
+
     const track = await this.database.getTrack(changeSessionPlayingTracksRequest.currentTrack.trackId);
     const playingTrack = new PlayingTrack(
       track.id,

--- a/apps/rpg-maestro/src/app/maestro-api/TracksDatabase.ts
+++ b/apps/rpg-maestro/src/app/maestro-api/TracksDatabase.ts
@@ -11,6 +11,8 @@ export interface TracksDatabase {
 
   upsertCurrentTrack: (sessionId: string, playingTrack: PlayingTrack) => Promise<SessionPlayingTracks>;
 
+  upsertShortEffectTrack: (sessionId: string, playingTrack: PlayingTrack) => Promise<SessionPlayingTracks>;
+
   getTrack(trackId: string): Promise<Track>;
 
   getAllTracks(sessionId: string): Promise<Track[]>;

--- a/apps/rpg-maestro/src/app/sessions/sessions.service.ts
+++ b/apps/rpg-maestro/src/app/sessions/sessions.service.ts
@@ -46,6 +46,12 @@ export class SessionsService {
     return updatedSession;
   }
 
+  async upsertShortEffectTrack(sessionId: string, playingTrack: PlayingTrack): Promise<SessionPlayingTracks> {
+    const updatedSession = await this.tracksDatabase.upsertShortEffectTrack(sessionId, playingTrack);
+    await this.cache.set(updatedSession);
+    return updatedSession;
+  }
+
   // only for admin
   async getAll(): Promise<SessionPlayingTracks[]> {
     return this.tracksDatabase.getAllSessions();

--- a/libs/rpg-maestro-api-contract/src/lib/ChangeSessionPlayingTracksRequest.ts
+++ b/libs/rpg-maestro-api-contract/src/lib/ChangeSessionPlayingTracksRequest.ts
@@ -1,5 +1,6 @@
 import { TrackToPlay } from './TrackToPlay';
 
 export interface ChangeSessionPlayingTracksRequest {
-  currentTrack: TrackToPlay;
+  currentTrack?: TrackToPlay;
+  shortEffectTrack?: TrackToPlay;
 }

--- a/libs/rpg-maestro-api-contract/src/lib/SessionPlayingTracks.ts
+++ b/libs/rpg-maestro-api-contract/src/lib/SessionPlayingTracks.ts
@@ -5,6 +5,7 @@ import { IsString, IsOptional, IsArray } from 'class-validator';
 export interface SessionPlayingTracks {
   sessionId: SessionID;
   currentTrack: PlayingTrack | null;
+  shortEffectTrack: PlayingTrack | null;
 }
 
 export type SessionID = string;

--- a/todo.md
+++ b/todo.md
@@ -9,6 +9,9 @@
     - as a Minstrel ?
   - redirect after login
   - create a homepage and self onboarding
+  - for track collections
+    - I'm pretting sure I am missing something!
+    - I'm wondering if I should not have a dedicated DB for TrackFile (!= from a SessionTrack)
 
 ## ideas
 - Youtube to mp3

--- a/todo.md
+++ b/todo.md
@@ -10,7 +10,7 @@
   - redirect after login
   - create a homepage and self onboarding
   - for track collections
-    - I'm pretting sure I am missing something!
+    - I'm pretty sure I am missing something!
     - I'm wondering if I should not have a dedicated DB for TrackFile (!= from a SessionTrack)
 
 ## ideas


### PR DESCRIPTION
## Summary
- Add `shortEffectTrack` field to `SessionPlayingTracks` and `ChangeSessionPlayingTracksRequest` API contracts
- Soundboard buttons now trigger effects via `shortEffectTrack` instead of `currentTrack`, so background music keeps playing
- Players receive effects through polling and play them in a dedicated hidden `<audio>` element (fire-and-forget, no loop)
- Backend: new `upsertShortEffectTrack` method across TracksDatabase interface, InMemory, Firestore, and SessionsService
- Add Soundboard track collection with 5 tracks to dev environment setup fixture
- Add unit tests for `SoundboardButton` component and expand `Soundboard` test coverage

## Test plan
- [x] `nx affected -t build` passes
- [x] `nx affected -t test` passes (all 21 tests + 9 soundboard tests)
- [ ] Run dev servers, seed with `.http` file, verify soundboard click doesn't interrupt background music
- [ ] Open player UI, verify sound effect plays overlaid on background music
- [ ] Verify clicking multiple effects in sequence works correctly