### PR TITLE
refactor(nx): clean up e2e server targets

### DIFF
--- a/apps/audio-file-uploader/project.json
+++ b/apps/audio-file-uploader/project.json
@@ -7,32 +7,10 @@
   "targets": {
     "dev-e2e": {
       "executor": "nx:run-commands",
+      "dependsOn": ["build"],
       "options": {
-        "commands": [{ "command": "nx run audio-file-uploader:serve --no-cloud" }]
-      },
-      "configurations": {
-        "e2e-tests": {
-          "envFile": "apps/audio-file-uploader/.env.e2e-tests"
-        }
-      }
-    },
-    "dev": {
-      "executor": "@nx/js:node",
-      "defaultConfiguration": "development",
-      "dependsOn": [
-        "build"
-      ],
-      "options": {
-        "buildTarget": "audio-file-uploader:build",
-        "runBuildTargetDependencies": false
-      },
-      "configurations": {
-        "development": {
-          "buildTarget": "audio-file-uploader:build:development"
-        },
-        "production": {
-          "buildTarget": "audio-file-uploader:build:production"
-        }
+        "command": "node dist/apps/audio-file-uploader/main.js",
+        "envFile": "apps/audio-file-uploader/.env.e2e-tests"
       }
     },
     "serve": {
@@ -50,16 +28,6 @@
         "production": {
           "buildTarget": "audio-file-uploader:build:production"
         }
-      }
-    },
-    "audio-file-uploader:build": {
-      "configurations": {
-        "production": {}
-      }
-    },
-    "audio-file-uploader:preview:e2e-tests": {
-      "configurations": {
-        "e2e-tests": {}
       }
     },
     "semantic-release": {

--- a/apps/rpg-maestro-ui-e2e/playwright.config.ts
+++ b/apps/rpg-maestro-ui-e2e/playwright.config.ts
@@ -26,7 +26,7 @@ export default defineConfig({
   /* Run your local dev server before starting the tests */
   webServer: [
     {
-      command: 'npx nx run rpg-maestro:dev-e2e --configuration=e2e-tests --no-cloud',
+      command: 'npx nx run rpg-maestro:dev-e2e --no-cloud',
       url: 'http://localhost:8099/health',
       reuseExistingServer: !process.env.CI,
       cwd: workspaceRoot,
@@ -34,7 +34,7 @@ export default defineConfig({
       stdout: 'pipe',
     },
     {
-      command: 'npx nx run audio-file-uploader:dev-e2e --configuration=e2e-tests --no-cloud',
+      command: 'npx nx run audio-file-uploader:dev-e2e --no-cloud',
       url: 'http://localhost:8098/api/health',
       reuseExistingServer: !process.env.CI,
       cwd: workspaceRoot,

--- a/apps/rpg-maestro-ui-e2e/project.json
+++ b/apps/rpg-maestro-ui-e2e/project.json
@@ -3,13 +3,11 @@
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "projectType": "application",
   "sourceRoot": "apps/rpg-maestro-ui-e2e/src",
-  "implicitDependencies": ["rpg-maestro-ui"],
+  "implicitDependencies": ["rpg-maestro-ui", "rpg-maestro", "audio-file-uploader"],
   "// targets": "to see all targets run: nx show project rpg-maestro-ui-e2e --web",
   "targets": {
     "e2e": {
-      "dependsOn": [
-        "rpg-maestro:build", "audio-file-uploader:build", "rpg-maestro-ui:build"
-      ]
+      "dependsOn": ["^build"]
     }
   }
 }

--- a/apps/rpg-maestro/project.json
+++ b/apps/rpg-maestro/project.json
@@ -7,13 +7,15 @@
   "targets": {
     "dev": {
       "executor": "nx:run-commands",
+      "defaultConfiguration": "development",
+      "dependsOn": ["build"],
       "options": {
         "commands": [
           {
-            "command": "nx run rpg-maestro:serve --no-cloud"
+            "command": "node dist/apps/rpg-maestro/main.js"
           },
           {
-            "command": "npx wait-on http://localhost:${PORT}/health --timeout 5000 && nx run rpg-maestro:setup-dev-env"
+            "command": "npx wait-on http://localhost:${PORT}/health --timeout 30000 && npx httpyac --all --bail apps/rpg-maestro/examples/SetupDevEnvironment.http"
           }
         ]
       },

--- a/apps/rpg-maestro/project.json
+++ b/apps/rpg-maestro/project.json
@@ -28,17 +28,10 @@
     },
     "dev-e2e": {
       "executor": "nx:run-commands",
+      "dependsOn": ["build"],
       "options": {
-        "commands": [
-          {
-            "command": "nx run rpg-maestro:serve --no-cloud"
-          }
-        ]
-      },
-      "configurations": {
-        "e2e-tests": {
-          "envFile": "apps/rpg-maestro/.env.e2e-tests"
-        }
+        "command": "node dist/apps/rpg-maestro/main.js",
+        "envFile": "apps/rpg-maestro/.env.e2e-tests"
       }
     },
     "setup-dev-env": {
@@ -69,11 +62,6 @@
         "production": {
           "buildTarget": "rpg-maestro:build:production"
         }
-      }
-    },
-    "rpg-maestro:build": {
-      "configurations": {
-        "production": {}
       }
     },
     "semantic-release": {


### PR DESCRIPTION
## Summary

- **Eliminates nested Nx invocations**: `dev-e2e` targets in `rpg-maestro` and `audio-file-uploader` used to call `nx run project:serve` inside `nx:run-commands`, bypassing the task graph. They now run `node dist/apps/.../main.js` directly with `envFile` baked in and `dependsOn: ["build"]` so the build precondition is explicit.
- **Removes orphaned stubs**: Both backend `project.json` files had invalid `project:target`-keyed entries that did nothing.
- **Removes duplicate target**: `audio-file-uploader` had a `dev` target identical to `serve` — removed.
- **Improves e2e project graph**: `rpg-maestro` and `audio-file-uploader` are now in `rpg-maestro-ui-e2e`'s `implicitDependencies`; `dependsOn` simplified from explicit cross-project build refs to `["^build"]`.
- **Simplifies playwright config**: `--configuration=e2e-tests` flag dropped from both backend `webServer` commands since the env file is now always loaded by the target.

## Test plan

- [ ] `nx build rpg-maestro` succeeds and produces `dist/apps/rpg-maestro/main.js`
- [ ] `nx build audio-file-uploader` succeeds and produces `dist/apps/audio-file-uploader/main.js`
- [ ] `nx e2e rpg-maestro-ui-e2e` starts all three servers and runs tests
- [ ] `reuseExistingServer` still works locally (servers stay up between re-runs)