### PR TITLE
fix(dev): remove from-directory request pointing at unreachable production URL

### DIFF
--- a/apps/rpg-maestro/examples/SetupDevEnvironment.http
+++ b/apps/rpg-maestro/examples/SetupDevEnvironment.http
@@ -78,18 +78,6 @@ Authorization: Bearer {{an_admin_user.token}}
   });
 %}
 
-####
-#### create from directory
-POST http://localhost:3000/maestro/sessions/{{session_id}}/tracks/from-directory
-Accept: application/json
-Content-Type: application/json
-Authorization: Bearer {{an_admin_user.token}}
-
-{
-  "directoryUrl": "https://rpgmaestro.app/public/musics",
-  "tags": ["combat", "travel"]
-}
-
 ###
 ### Create Soundboard track collection
 POST http://localhost:3000/track-collections


### PR DESCRIPTION
## Problem

`SetupDevEnvironment.http` contained a `POST .../tracks/from-directory` request pointing at `https://rpgmaestro.app/public/musics` — a Cloudflare Tunnel URL that is not reachable in local dev. This caused a 530 error and a server-side ERROR log on every `nx run rpg-maestro:dev`.

## Root cause

The `from-directory` endpoint calls `getAllFilesFromFileServerDirectory(directoryUrl)` which expects a Caddy-format JSON directory listing. The local `audio-file-uploader` uses `ServeStaticModule` and doesn't expose a compatible directory index, so there's no local URL to substitute.

## Fix

Remove the request. Individual tracks are already seeded earlier in the script, so no seed data is lost.

## Test plan

- [ ] `nx run rpg-maestro:dev --no-cloud` completes with `8 requests processed (8 succeeded)` and no ERROR logs