### PR TITLE
test(e2e): expand coverage for soundboard, player UI, and track management

### DIFF
--- a/apps/rpg-maestro-ui-e2e/src/fixtures.ts
+++ b/apps/rpg-maestro-ui-e2e/src/fixtures.ts
@@ -70,3 +70,50 @@ export async function initUsersFixtureSpec(){
     return await initUsersFixture(RPG_MAESTRO_URL);
   });
 }
+
+export interface CreateTrackOptions {
+  url: string;
+  name?: string;
+  tags?: string[];
+}
+
+export async function createTrackViaApi(
+  jwtToken: FakeJwtToken,
+  sessionId: string,
+  options: CreateTrackOptions
+): Promise<{ id: string; name: string; tags: string[] }> {
+  return await test.step(`create track "${options.name ?? options.url}"`, async () => {
+    const res = await fetch(`${RPG_MAESTRO_URL}/maestro/sessions/${sessionId}/tracks`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${jwtToken.token}`,
+      },
+      body: JSON.stringify(options),
+    });
+    if (!res.ok) {
+      throw new Error(`Failed to create track: ${res.status} ${res.statusText}`);
+    }
+    return res.json();
+  });
+}
+
+export async function setTrackToPlayViaApi(
+  jwtToken: FakeJwtToken,
+  sessionId: string,
+  trackId: string
+): Promise<void> {
+  await test.step(`set track ${trackId} to play via api`, async () => {
+    const res = await fetch(`${RPG_MAESTRO_URL}/maestro/sessions/${sessionId}/playing-tracks`, {
+      method: 'PUT',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${jwtToken.token}`,
+      },
+      body: JSON.stringify({ currentTrack: { trackId, paused: false } }),
+    });
+    if (!res.ok) {
+      throw new Error(`Failed to set track to play: ${res.status} ${res.statusText}`);
+    }
+  });
+}

--- a/apps/rpg-maestro-ui-e2e/src/maestro-soundboard.spec.ts
+++ b/apps/rpg-maestro-ui-e2e/src/maestro-soundboard.spec.ts
@@ -1,0 +1,182 @@
+import { expect, test } from '@playwright/test';
+import {
+  createTrackViaApi,
+  generateNewSession,
+  initUsersFixtureSpec,
+  RPG_MAESTRO_URL,
+  UserWithGeneratedSession,
+} from './fixtures';
+import { goToMaestroPage, simulateAuthenticatedInBrowser, waitForAppToBeReady } from './navigation';
+import { TestUsersFixture } from '@rpg-maestro/test-utils';
+
+// Run tests within this file serially to share one backend in-memory session without races
+test.describe.configure({ mode: 'serial' });
+
+let userFixture: TestUsersFixture;
+
+test.beforeAll(async ({ browser }) => {
+  const page = await browser.newPage();
+  await waitForAppToBeReady(page);
+  userFixture = await initUsersFixtureSpec();
+  await page.close();
+});
+
+test('a Maestro can filter tracks by quick tag (single click)', async ({ page }) => {
+  let user: UserWithGeneratedSession;
+  let combatTrackName: string;
+  let travelTrackName: string;
+
+  await test.step('prepare data: create two tracks with different tags', async () => {
+    user = await generateNewSession(userFixture.a_maestro_user);
+
+    const combatTrack = await createTrackViaApi(user, user.sessionId, {
+      url: `${RPG_MAESTRO_URL}/public/race1.ogg`,
+      name: 'combat-track-test',
+      tags: ['combat'],
+    });
+    combatTrackName = combatTrack.name;
+
+    const travelTrack = await createTrackViaApi(user, user.sessionId, {
+      url: `${RPG_MAESTRO_URL}/public/race1.ogg`,
+      name: 'travel-track-test',
+      tags: ['travel'],
+    });
+    travelTrackName = travelTrack.name;
+  });
+
+  await simulateAuthenticatedInBrowser(page, user);
+  await goToMaestroPage(page, user.sessionId);
+
+  await test.step('both tracks are visible before filtering', async () => {
+    await expect(page.locator('.MuiDataGrid-row', { hasText: combatTrackName })).toBeVisible();
+    await expect(page.locator('.MuiDataGrid-row', { hasText: travelTrackName })).toBeVisible();
+  });
+
+  await test.step('single click on "combat" quick tag filters tracks table', async () => {
+    await page.locator('button', { hasText: 'combat' }).click();
+    await expect(page.locator('.MuiDataGrid-row', { hasText: combatTrackName })).toBeVisible();
+    await expect(page.locator('.MuiDataGrid-row', { hasText: travelTrackName })).not.toBeVisible();
+  });
+});
+
+test('a Maestro can search for a specific track by name', async ({ page }) => {
+  let user: UserWithGeneratedSession;
+  let trackAName: string;
+  let trackBName: string;
+
+  await test.step('prepare data: create two tracks', async () => {
+    user = await generateNewSession(userFixture.a_maestro_B_user);
+
+    const trackA = await createTrackViaApi(user, user.sessionId, {
+      url: `${RPG_MAESTRO_URL}/public/race1.ogg`,
+      name: 'dragon-theme-unique',
+    });
+    trackAName = trackA.name;
+
+    const trackB = await createTrackViaApi(user, user.sessionId, {
+      url: `${RPG_MAESTRO_URL}/public/race1.ogg`,
+      name: 'tavern-ambience-unique',
+    });
+    trackBName = trackB.name;
+  });
+
+  await simulateAuthenticatedInBrowser(page, user);
+  await goToMaestroPage(page, user.sessionId);
+
+  await test.step('both tracks are visible in the table', async () => {
+    await expect(page.locator('.MuiDataGrid-row', { hasText: trackAName })).toBeVisible();
+    await expect(page.locator('.MuiDataGrid-row', { hasText: trackBName })).toBeVisible();
+  });
+
+  await test.step('searching by name filters the tracks table', async () => {
+    const searchInput = page.getByRole('combobox', { name: 'Search specific track' });
+    await searchInput.click();
+    await searchInput.fill(trackAName);
+    await page.getByRole('option', { name: trackAName }).click();
+
+    await expect(page.locator('.MuiDataGrid-row', { hasText: trackAName })).toBeVisible();
+    await expect(page.locator('.MuiDataGrid-row', { hasText: trackBName })).not.toBeVisible();
+  });
+});
+
+test('a Maestro can open the track edit form and update the track name', async ({ page }) => {
+  let user: UserWithGeneratedSession;
+  let trackName: string;
+
+  await test.step('prepare data', async () => {
+    user = await generateNewSession(userFixture.a_maestro_user);
+
+    const track = await createTrackViaApi(user, user.sessionId, {
+      url: `${RPG_MAESTRO_URL}/public/race1.ogg`,
+      name: 'track-to-edit',
+    });
+    trackName = track.name;
+  });
+
+  await simulateAuthenticatedInBrowser(page, user);
+  await goToMaestroPage(page, user.sessionId);
+
+  await test.step('open the edit form for the track', async () => {
+    const row = page.locator('.MuiDataGrid-row', { hasText: trackName });
+    await expect(row).toBeVisible();
+
+    await row.hover();
+
+    // The Edit action may be inline or in the "..." overflow menu
+    const moreActionsButton = row.getByRole('button', { name: 'More actions' });
+    if (await moreActionsButton.isVisible()) {
+      await moreActionsButton.click();
+      await page.getByRole('menuitem', { name: 'Edit' }).click();
+    } else {
+      await row.getByRole('menuitem', { name: 'Edit' }).click();
+    }
+  });
+
+  await test.step('edit drawer opens with the track name pre-filled', async () => {
+    await expect(page.getByRole('heading', { name: /Update track/i })).toBeVisible();
+    await expect(page.getByLabel('Name (optional)')).toHaveValue(trackName);
+  });
+
+  await test.step('update the track name', async () => {
+    const newName = 'renamed-track-e2e';
+    await page.getByLabel('Name (optional)').fill(newName);
+    await page.getByRole('button', { name: 'Update track' }).click();
+
+    await expect(page.getByRole('heading', { name: /Update track/i })).not.toBeVisible();
+    await expect(page.locator('.MuiDataGrid-row', { hasText: newName })).toBeVisible();
+  });
+});
+
+test('a Maestro can navigate from soundboard to tracks management', async ({ page }) => {
+  let user: UserWithGeneratedSession;
+
+  await test.step('prepare data', async () => {
+    user = await generateNewSession(userFixture.a_maestro_B_user);
+  });
+
+  await simulateAuthenticatedInBrowser(page, user);
+  await goToMaestroPage(page, user.sessionId);
+
+  await test.step('click "Manage your tracks" link and reach tracks management page', async () => {
+    await page.getByText('Manage your tracks').click();
+    await expect(page.locator('h1')).toContainText('Tracks management');
+    expect(page.url()).toContain(`/maestro/manage/${user.sessionId}`);
+  });
+});
+
+test('a Maestro can navigate from soundboard to the player view', async ({ page }) => {
+  let user: UserWithGeneratedSession;
+
+  await test.step('prepare data', async () => {
+    user = await generateNewSession(userFixture.a_maestro_user);
+  });
+
+  await simulateAuthenticatedInBrowser(page, user);
+  await goToMaestroPage(page, user.sessionId);
+
+  await test.step('click "see what your players are seeing" link', async () => {
+    await page.getByText('see what your players are seeing').click();
+    await expect(page.locator('h1')).toContainText('RPG-Maestro player UI');
+    expect(page.url()).toContain(`/${user.sessionId}`);
+  });
+});

--- a/apps/rpg-maestro-ui-e2e/src/players-ui.spec.ts
+++ b/apps/rpg-maestro-ui-e2e/src/players-ui.spec.ts
@@ -1,0 +1,110 @@
+import { expect, test } from '@playwright/test';
+import {
+  createTrackViaApi,
+  generateNewSession,
+  initUsersFixtureSpec,
+  RPG_MAESTRO_URL,
+  setTrackToPlayViaApi,
+  UserWithGeneratedSession,
+} from './fixtures';
+import { simulateAuthenticatedInBrowser, waitForAppToBeReady } from './navigation';
+import { TestUsersFixture } from '@rpg-maestro/test-utils';
+
+// Run tests within this file serially to share one backend in-memory session without races
+test.describe.configure({ mode: 'serial' });
+
+let userFixture: TestUsersFixture;
+
+test.beforeAll(async ({ browser }) => {
+  const page = await browser.newPage();
+  await waitForAppToBeReady(page);
+  userFixture = await initUsersFixtureSpec();
+  await page.close();
+});
+
+test('the Players UI renders the audio player and a link back to the Maestro', async ({ page }) => {
+  let user: UserWithGeneratedSession;
+
+  await test.step('prepare data', async () => {
+    user = await generateNewSession(userFixture.a_maestro_user);
+  });
+
+  await test.step('go to player page (no auth required)', async () => {
+    await page.goto(`/${user.sessionId}`);
+    await expect(page.locator('h1')).toContainText('RPG-Maestro player UI');
+  });
+
+  await test.step('audio player is present on the page', async () => {
+    await expect(page.locator('.rhap_container')).toBeVisible();
+  });
+
+  await test.step('link to the maestro interface is visible', async () => {
+    await expect(page.getByText('Maestro interface is available here')).toBeVisible();
+  });
+});
+
+test('the Players UI displays the track name when the Maestro sets a current track', async ({ page }) => {
+  let user: UserWithGeneratedSession;
+  let trackName: string;
+
+  await test.step('prepare data: create a session and set a track to play', async () => {
+    user = await generateNewSession(userFixture.a_maestro_B_user);
+
+    const track = await createTrackViaApi(user, user.sessionId, {
+      url: `${RPG_MAESTRO_URL}/public/race1.ogg`,
+      name: 'battle-theme-players-test',
+    });
+    trackName = track.name;
+    await setTrackToPlayViaApi(user, user.sessionId, track.id);
+  });
+
+  await test.step('players page shows the track name in the audio player header', async () => {
+    await page.goto(`/${user.sessionId}`);
+    await expect(page.locator('h1')).toContainText('RPG-Maestro player UI');
+
+    await expect(page.getByText('You are listening to:')).toBeVisible();
+    await expect(page.getByText(trackName)).toBeVisible({ timeout: 5000 });
+  });
+});
+
+test('the Players UI updates the displayed track name when the Maestro changes the track', async ({ page }) => {
+  let user: UserWithGeneratedSession;
+  let firstTrackName: string;
+  let secondTrackName: string;
+  let firstTrackId: string;
+  let secondTrackId: string;
+
+  await test.step('prepare data: two tracks, first one playing', async () => {
+    user = await generateNewSession(userFixture.a_maestro_user);
+
+    const first = await createTrackViaApi(user, user.sessionId, {
+      url: `${RPG_MAESTRO_URL}/public/race1.ogg`,
+      name: 'first-track-sync-test',
+    });
+    firstTrackName = first.name;
+    firstTrackId = first.id;
+
+    const second = await createTrackViaApi(user, user.sessionId, {
+      url: `${RPG_MAESTRO_URL}/public/race1.ogg`,
+      name: 'second-track-sync-test',
+    });
+    secondTrackName = second.name;
+    secondTrackId = second.id;
+
+    await setTrackToPlayViaApi(user, user.sessionId, firstTrackId);
+  });
+
+  await test.step('player page shows first track', async () => {
+    await page.goto(`/${user.sessionId}`);
+    await expect(page.getByText(firstTrackName)).toBeVisible({ timeout: 5000 });
+  });
+
+  await test.step('maestro switches to second track via API', async () => {
+    await setTrackToPlayViaApi(user, user.sessionId, secondTrackId);
+  });
+
+  await test.step('player page automatically syncs to the second track', async () => {
+    await expect(page.getByText(secondTrackName)).toBeVisible({ timeout: 5000 });
+    await expect(page.getByText(firstTrackName)).not.toBeVisible();
+  });
+});

--- a/apps/rpg-maestro-ui-e2e/src/track-management.spec.ts
+++ b/apps/rpg-maestro-ui-e2e/src/track-management.spec.ts
@@ -1,0 +1,88 @@
+import { expect, test } from '@playwright/test';
+import { generateNewSession, initUsersFixtureSpec, RPG_MAESTRO_URL, UserWithGeneratedSession } from './fixtures';
+import { simulateAuthenticatedInBrowser, waitForAppToBeReady } from './navigation';
+import { TestUsersFixture } from '@rpg-maestro/test-utils';
+
+// Run tests within this file serially to share one backend in-memory session without races
+test.describe.configure({ mode: 'serial' });
+
+let userFixture: TestUsersFixture;
+
+test.beforeAll(async ({ browser }) => {
+  const page = await browser.newPage();
+  await waitForAppToBeReady(page);
+  userFixture = await initUsersFixtureSpec();
+  await page.close();
+});
+
+async function goToTracksManagement(page: import('@playwright/test').Page, sessionId: string) {
+  await page.goto(`/maestro/manage/${sessionId}`);
+  await expect(page.locator('h1')).toContainText('Tracks management');
+}
+
+test('the Create track form shows a validation error when URL is too short', async ({ page }) => {
+  let user: UserWithGeneratedSession;
+
+  await test.step('prepare data', async () => {
+    user = await generateNewSession(userFixture.a_maestro_user);
+  });
+
+  await simulateAuthenticatedInBrowser(page, user);
+  await goToTracksManagement(page, user.sessionId);
+
+  await test.step('entering a too-short URL shows a validation error and disables the submit button', async () => {
+    // The form validates when inputUrl.length < 3 or inputUrl is null
+    await page.getByLabel('URL').fill('ht');
+
+    await expect(page.getByText('valid URL is required')).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Create track' })).toBeDisabled();
+  });
+});
+
+test('a Maestro can create a track with a name and tags', async ({ page }) => {
+  let user: UserWithGeneratedSession;
+
+  await test.step('prepare data', async () => {
+    user = await generateNewSession(userFixture.a_maestro_B_user);
+  });
+
+  await simulateAuthenticatedInBrowser(page, user);
+  await goToTracksManagement(page, user.sessionId);
+
+  await test.step('fill the form with URL, name, and tags', async () => {
+    await page.getByLabel('URL').fill(`${RPG_MAESTRO_URL}/public/race1.ogg`);
+    await page.getByLabel('Name (optional)').fill('my-named-track-e2e');
+
+    await page.getByLabel('Tags (optional)').click();
+    await page.getByLabel('Tags (optional)').fill('forest');
+    await page.keyboard.press('Enter');
+  });
+
+  await test.step('submit the form and see success toast', async () => {
+    await page.getByRole('button', { name: 'Create track' }).click();
+    await expect(page.getByText(/Track created/i)).toBeVisible({ timeout: 10000 });
+  });
+
+  await test.step('new track appears on the maestro soundboard', async () => {
+    await page.goto(`/maestro/${user.sessionId}`);
+    await expect(page.locator('h1')).toContainText('Maestro UI');
+    await expect(page.locator('.MuiDataGrid-row', { hasText: 'my-named-track-e2e' })).toBeVisible();
+  });
+});
+
+test('a Maestro can navigate back to the soundboard from tracks management', async ({ page }) => {
+  let user: UserWithGeneratedSession;
+
+  await test.step('prepare data', async () => {
+    user = await generateNewSession(userFixture.a_maestro_user);
+  });
+
+  await simulateAuthenticatedInBrowser(page, user);
+  await goToTracksManagement(page, user.sessionId);
+
+  await test.step('click "Go back to Maestro ui" and reach the soundboard', async () => {
+    await page.getByText('Go back to Maestro ui').click();
+    await expect(page.locator('h1')).toContainText('Maestro UI');
+    expect(page.url()).toContain(`/maestro/${user.sessionId}`);
+  });
+});


### PR DESCRIPTION
## Summary

Adds 11 new E2E tests across 3 spec files to cover the critical user paths that will be impacted by an upcoming UI/CSS rewrite:

**maestro-soundboard.spec.ts** (5 tests):
- Quick tag single-click filters the tracks table by tag
- Search by track name filters the table via autocomplete
- Edit side form opens pre-filled, track name update persists
- Navigation: soundboard → tracks management
- Navigation: soundboard → player view

**players-ui.spec.ts** (3 tests):
- Player page renders with audio player and maestro link
- Track name is displayed when maestro sets a playing track
- Track name auto-syncs when maestro switches to a different track

**track-management.spec.ts** (3 tests):
- URL too-short shows validation error and disables submit button
- Track creation with name and tags → success toast → appears in soundboard
- Navigation: tracks management → soundboard

**Also**:
- `fixtures.ts` extended with `createTrackViaApi` and `setTrackToPlayViaApi` API helpers
- All new spec files use `test.describe.configure({ mode: 'serial' })` + shared `beforeAll` to avoid the pre-existing parallel JWK race condition in the in-memory backend

## Test plan

- [x] Ran all 15 tests (4 existing + 11 new) sequentially locally: 15/15 passed
- [x] Sequential mode matches CI (`workers: 1` in CI per nxE2EPreset)
- [x] Existing tests unchanged and still pass