### PR TITLE
docs: architecture reference, dev guide, and doc-update hook

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "Stop": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node -e \"const {execSync}=require('child_process'),patterns=[/apps\\/rpg-maestro\\/src\\/app\\/.*\\.module\\.ts$/,/apps\\/rpg-maestro\\/src\\/app-bootstrap\\.ts$/,/apps\\/rpg-maestro\\/src\\/app\\/.*\\.controller\\.ts$/,/apps\\/rpg-maestro-ui\\/src\\/app\\/app\\.tsx$/,/libs\\/(rpg-maestro|audio-file-uploader)-api-contract\\/src\\/lib\\//,/apps\\/rpg-maestro\\/src\\/infrastructure\\/database\\.module\\.ts$/,/apps\\/.*\\/project\\.json$/];try{const f=execSync('git diff --name-only HEAD 2>/dev/null||true',{cwd:process.cwd()}).toString().trim().split('\\n').filter(Boolean),hit=f.filter(x=>patterns.some(p=>p.test(x)));if(hit.length)console.log('\\n[doc-hook] Architecture-affecting files changed:\\n  '+hit.join('\\n  ')+'\\nConsider updating docs/architecture.md or docs/dev-guide.md if the module structure, API surface, routes, or DB layer changed.')}catch(e){}\""
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,334 @@
+# RPG Maestro — Architecture Reference
+
+> Auto-maintained by Claude. Update this file when adding or refactoring a major module,
+> changing the database layer, auth flow, API surface, or deployment topology.
+
+## System Overview
+
+RPG Maestro is an Nx monorepo for broadcasting music during tabletop RPG sessions.
+A Maestro controls track playback from a soundboard UI; Audience members see the
+currently-playing track in real time via a public player page.
+
+```
+┌─────────────────────────────────────────────────────────────────────┐
+│                          Browser                                     │
+│  ┌──────────────────────┐    ┌──────────────────────────────────┐   │
+│  │  rpg-maestro-ui      │    │  rpg-maestro-ui (player page)    │   │
+│  │  /maestro/:sessionId │    │  /:sessionId                     │   │
+│  │  Auth0 → JWT         │    │  No auth required                │   │
+│  └──────────┬───────────┘    └─────────────────┬────────────────┘   │
+└─────────────┼───────────────────────────────────┼───────────────────┘
+              │ PUT playing-tracks                 │ GET playing-tracks (poll)
+              ▼                                    ▼
+┌─────────────────────────────────────────────────────────────────────┐
+│                  rpg-maestro (NestJS, port 3000)                     │
+│                                                                      │
+│  JwtAuthGuard ──► RolesGuard ──► Controllers ──► Services           │
+│                                                          │           │
+│  Modules:                                                ▼           │
+│  maestro-api | sessions | users-management               DB          │
+│  track-collection | auth | admin | health                │           │
+│                                               ┌──────────┴────────┐  │
+│                                               │  TracksDatabase   │  │
+│                                               │  UsersDatabase    │  │
+│                                               │  CollectionsDB    │  │
+│                                               └──────────┬────────┘  │
+│                                                          │           │
+│                                            ┌─────────────┴─────────┐ │
+│                                            │ DATABASE env var       │ │
+│                                            │  in-memory (dev)       │ │
+│                                            │  firestore  (prod)     │ │
+│                                            └───────────────────────┘ │
+└──────────────────────────────────────────┬──────────────────────────┘
+                                           │ HTTP client
+                                           ▼
+┌──────────────────────────────────────────────────────────────────────┐
+│              audio-file-uploader (NestJS, port 3001)                 │
+│                                                                      │
+│  POST /api/upload/audio          ← multipart file upload             │
+│  POST /api/upload/audio/from-youtube  ← queue YouTube job           │
+│  GET  /api/upload/audio/from-youtube  ← poll job status             │
+│                                                                      │
+│  ytdl-core → FFmpeg → /uploads/  (served as static /public/)        │
+└──────────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## Apps
+
+### rpg-maestro (NestJS Backend)
+
+| Item | Value |
+|------|-------|
+| Port (dev) | 3000 |
+| Port (e2e) | 8099 |
+| Entry point | `src/main.ts` → `src/app-bootstrap.ts` |
+| Swagger docs | `http://localhost:3000/api` |
+| Dockerfile | Alpine + FFmpeg |
+
+**Module map:**
+
+```
+AppModule
+├── DatabaseModule          DB provider (in-memory | firestore)
+├── MaestroApiModule        Track CRUD, YouTube uploads, playback state
+│   ├── TrackService
+│   ├── ManageCurrentlyPlayingTracks
+│   ├── OnboardingService
+│   └── TrackCreationFromYoutubeJobsWatcher
+├── SessionsModule          Session state
+├── UsersManagementModule   User profiles + role management
+├── TrackCollectionModule   Pre-built collections
+├── AuthGuardsModule        JWT + RBAC
+├── AdminModule             Admin endpoints
+├── HealthModule            GET /health
+└── TestsUtilsModule        Dev-only fake IDP + fixtures
+```
+
+**Key controllers:**
+
+| Controller | Base path | Auth |
+|-----------|-----------|------|
+| `AuthenticatedMaestroController` | `/maestro` | JWT + Roles |
+| `PlayersController` | `/` | None |
+| `HealthController` | `/health` | None |
+| `TestsUtilsController` | `/test-utils` | None (dev only) |
+
+**Environment variables:**
+
+| Variable | Dev value | Purpose |
+|----------|-----------|---------|
+| `DATABASE` | `in-memory` | DB driver (`in-memory` \| `firestore`) |
+| `PORT` | `3000` | HTTP port |
+| `AUTH_ISSUER` | `http://localhost:3000/test-utils/fake-idp` | JWT issuer |
+| `AUTH_JWT_AUDIENCE` | `http://localhost:3000` | JWT audience |
+| `DEFAULT_FRONTEND_DOMAIN` | `http://localhost:4200` | CORS origin |
+| `DEFAULT_AUDIO_FILE_UPLOADER_API_URL` | `http://localhost:3001/api` | Audio service |
+| `NODE_ENV` | `dev` | Node environment |
+| `FFMPEG_PATH` / `FFPROBE_PATH` | (system default) | Audio processing |
+
+---
+
+### audio-file-uploader (NestJS Service)
+
+| Item | Value |
+|------|-------|
+| Port (dev) | 3001 |
+| Port (e2e) | 8098 |
+| Entry point | `src/main.ts` |
+| Static assets | `/public` (served from `./uploads/`) |
+
+**Endpoints:**
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| `GET` | `/health` | Health check |
+| `POST` | `/api/upload/audio` | Multipart file upload |
+| `POST` | `/api/upload/audio/from-youtube` | Queue YouTube extraction (202) |
+| `GET` | `/api/upload/audio/from-youtube` | List extraction jobs |
+
+**YouTube pipeline:** `ytdl-core` → raw audio → `FFmpeg` → MP3 → `/uploads/` → served via `/public/`
+
+---
+
+### rpg-maestro-ui (React + Vite Frontend)
+
+| Item | Value |
+|------|-------|
+| Port (dev) | 4200 |
+| Port (preview/e2e) | 4300 |
+| Entry point | `src/main.tsx` → `src/app/app.tsx` |
+| Bundler | Vite 7.x |
+| Style | styled-components 5 + MUI dark theme |
+
+**Route map:**
+
+| Route | Component | Auth |
+|-------|-----------|------|
+| `/` | `WelcomePage` | None |
+| `/login` | `LoginPage` | None |
+| `/health` | `HealthStatus` | None |
+| `/onboarding` | `Onboarding` | Required |
+| `/onboarding/setup-session` | `SetupSession` | Required |
+| `/maestro/infos` | User profile | Required |
+| `/maestro/:sessionId` | `MaestroSoundboard` | Required |
+| `/maestro/manage/:sessionId` | `TracksManagement` | Required |
+| `/maestro/track-collections` | `TrackCollections` | Required |
+| `/maestro/admin` | `AdminBoard` | Required (ADMIN) |
+| `/:sessionId` | `PlayersUi` | None |
+| `/dev/fake-idp-login-page` | Dev fixture | Dev mode only |
+
+**Environment variables (Vite `VITE_` prefix):**
+
+| Variable | Purpose |
+|----------|---------|
+| `VITE_AUTH0_DOMAIN` | Auth0 tenant domain |
+| `VITE_AUTH0_CLIENT_ID` | Auth0 SPA client ID |
+| `VITE_RPG_MAESTRO_API_URL` | Backend API base URL |
+
+**Feature flag:** `localStorage.getItem('isDevMode') === 'true'` → enables fake IDP
+
+---
+
+## Shared Libraries
+
+### rpg-maestro-api-contract
+
+Path alias: `@rpg-maestro/rpg-maestro-api-contract`
+
+Core types shared between backend and frontend:
+
+| Type | Purpose |
+|------|---------|
+| `Track` | Track entity (id, sessionId, url, name, duration, tags, source) |
+| `PlayingTrack` | Track with playback state (isPaused, playTimestamp, trackStartTime) |
+| `SessionPlayingTracks` | Session state (currentTrack, shortEffectTrack) |
+| `User` | User entity (id, role, sessions) |
+| `TrackCollection` | Curated collection with tracks |
+| `TrackCreation` / `TrackUpdate` | Request DTOs |
+| `ChangeSessionPlayingTracksRequest` | Playback control DTO |
+| `UploadAndCreateTracksFromYoutubeRequest` | YouTube upload DTO |
+
+**Roles:**
+
+```typescript
+enum Role { MAESTRO = 'MAESTRO', MINSTREL = 'MINSTREL', ADMIN = 'ADMIN' }
+```
+
+### audio-file-uploader-api-contract
+
+Path alias: `@rpg-maestro/audio-file-uploader-api-contract`
+
+| Type | Purpose |
+|------|---------|
+| `UploadAudioFromYoutubeRequest` | `{ urls: string[] }` |
+| `UploadAudioFromYoutubeJobDto` | Job status DTO |
+
+### test-utils
+
+Path alias: `@rpg-maestro/test-utils`
+
+| Export | Purpose |
+|--------|---------|
+| `generateFakeJwtToken()` | RS256-signed fake JWT for testing |
+| `initUsersFixture()` | Creates 5 test users via API |
+| `getJWKS()` | JWKS response for fake IDP |
+| `randomEmail()` | Random email generator |
+
+---
+
+## Database Layer
+
+The system uses a **pluggable database pattern** controlled by `DATABASE` env var.
+
+```
+DatabaseModule
+  DatabaseWrapperConfiguration(process.env.DATABASE)
+    ├── 'in-memory' → InMemory{Tracks,Users,TrackCollection}Database
+    └── 'firestore' → Firestore{Tracks,Users,TrackCollections}Database
+```
+
+**Firestore collections (production):**
+
+| Collection | Contents |
+|-----------|----------|
+| `rpg-maestro-sessions` | `SessionPlayingTracks` keyed by sessionId |
+| `rpg-maestro-tracks` | `Track` entities |
+| `rpg-maestro-users` | `User` entities |
+| `rpg-maestro-track-collections` | `TrackCollection` entities |
+
+**Adding a new DB entity:** implement the interface in both `in-memory/` and `firestore/`, register in `DatabaseModule`, expose via `DatabaseWrapperConfiguration`.
+
+---
+
+## Authentication Flow
+
+### Production (Auth0)
+
+```
+Browser                       Backend
+  │                              │
+  ├─ Auth0 login flow            │
+  ├─ getAccessTokenSilently()    │
+  ├─ PUT /maestro/... ──────────►│
+  │   Authorization: Bearer JWT  │
+  │                              ├─ JwtAuthGuard
+  │                              │   createRemoteJWKSet(AUTH_ISSUER/.well-known/jwks.json)
+  │                              │   jwtVerify(token, jwks, { issuer, audience })
+  │                              │   → email as UserID
+  │                              ├─ RolesGuard
+  │                              │   user.role ∈ @Roles([...])
+  │                              └─ Handler
+```
+
+### Development (Fake IDP)
+
+```
+Browser                       Backend
+  │                              │
+  ├─ /dev/fake-idp-login-page    │
+  ├─ POST /test-utils/fake-idp   │ ← generates RS256 keypair
+  ├─ token returned              │
+  ├─ authenticatedFetch()        │
+  │   Authorization: Bearer JWT  │
+  │                              ├─ JwtAuthGuard
+  │                              │   GET /test-utils/fake-idp (JWKS)
+  │                              │   jwtVerify(token, localJWKS)
+  │                              └─ Handler
+```
+
+**JWT claims:** `email` (UserID), `sub`, `aud`, `iss`, `exp` (10 min), `iat`
+
+---
+
+## Real-Time Playback (Polling)
+
+No WebSockets. Audience pages poll `/sessions/:id/playing-tracks` every N seconds.
+Maestro writes state via `PUT /maestro/sessions/:sessionId/playing-tracks`.
+
+**`PlayingTrack` fields enable client-side sync:**
+- `playTimestamp` — wall-clock time when playback started
+- `trackStartTime` — position in seconds where playback began
+- `isPaused` — pause state
+
+Client reconstructs current position as `(Date.now() - playTimestamp) / 1000 + trackStartTime`.
+
+---
+
+## CI/CD
+
+### GitHub Actions
+
+| Workflow | Trigger | Steps |
+|----------|---------|-------|
+| `main.yaml` | push to main | lint → test → deploy (Docker Hub) + webhook |
+| `pull_request.yaml` | PR open/sync | lint → test |
+
+**Nx target dependency chain:** `build` → `lint` → `test` → `e2e`
+
+### Docker Images
+
+| App | Base | Extra |
+|-----|------|-------|
+| `rpg-maestro` | `node:22-alpine` | `apk add ffmpeg` |
+| `audio-file-uploader` | `node:22-alpine` | — |
+| `rpg-maestro-ui` | `node:22-alpine` | Nginx or static |
+
+**Build:** `npx nx docker-build <project>`  
+**Push:** `npx nx deploy <project>` (pushes to `acevedor/<project>:latest`)
+
+---
+
+## Key Architectural Decisions
+
+| Decision | Rationale |
+|----------|-----------|
+| Nx monorepo | Shared types, atomic releases, affected-only CI |
+| Pluggable DB (in-memory / Firestore) | Fast local dev without cloud deps |
+| Separate audio-file-uploader service | Isolates FFmpeg/ytdl complexity + heavy file I/O |
+| Shared API contracts in libs | Single source of truth, compile-time type safety |
+| Polling for real-time sync | Simpler than WebSockets; acceptable latency for RPG use case |
+| Fake IDP for dev | No Auth0 tenant required for local dev |
+| MUI dark theme | Fits the RPG atmosphere; consistent component library |
+| Role enum (MAESTRO/MINSTREL/ADMIN) | Granular access control without OAuth scopes |

--- a/docs/dev-guide.md
+++ b/docs/dev-guide.md
@@ -1,0 +1,149 @@
+# RPG Maestro — Developer Quick Reference
+
+> Auto-maintained by Claude. Keep in sync with CLAUDE.md and architecture.md.
+
+## Local Dev Setup
+
+```bash
+npm ci
+
+# Terminal 1 — Backend API
+npx nx run rpg-maestro:dev         # http://localhost:3000
+                                   # Swagger: http://localhost:3000/api
+
+# Terminal 2 — Audio uploader
+npx nx run audio-file-uploader:dev  # http://localhost:3001
+
+# Terminal 3 — Frontend
+npx nx run rpg-maestro-ui:serve    # http://localhost:4200
+```
+
+Enable dev mode (fake IDP, no Auth0):
+```
+localStorage.setItem('isDevMode', 'true')
+# then go to http://localhost:4200/dev/fake-idp-login-page
+```
+
+## Commands
+
+```bash
+# Lint / Build / Test — affected projects only
+npx nx affected -t lint
+npx nx affected -t build
+npx nx affected -t test
+
+# Single project
+npx nx lint rpg-maestro
+npx nx build rpg-maestro
+npx nx test rpg-maestro
+
+# Run one spec file
+npx nx test rpg-maestro --testFile=apps/rpg-maestro/src/app/maestro-api/TrackService.spec.ts
+
+# Run tests matching a name pattern
+npx nx test rpg-maestro -- --testNamePattern "should return the created track"
+
+# E2E — requires all three services running on e2e ports
+npx nx e2e rpg-maestro-ui-e2e
+npx nx e2e rpg-maestro-ui-e2e -- --grep "play a track"
+npx nx e2e rpg-maestro-ui-e2e -- apps/rpg-maestro-ui-e2e/src/e2e.spec.ts
+
+# Docker build & push
+npx nx docker-build rpg-maestro
+npx nx deploy rpg-maestro
+```
+
+## Environment Files
+
+| File | Used by |
+|------|---------|
+| `apps/rpg-maestro/.env.development` | `nx run rpg-maestro:dev` |
+| `apps/rpg-maestro/.env.e2e-tests` | E2E test runner |
+| `apps/audio-file-uploader/.env.e2e-tests` | E2E test runner |
+| `apps/rpg-maestro-ui/.env` | Vite dev server (create from `.env.example` if present) |
+
+## Adding a New Feature — Checklist
+
+1. **Backend module** — create under `apps/rpg-maestro/src/app/<module>/`
+   - `<module>.module.ts` with providers + controllers
+   - Import in `app.module.ts`
+2. **API contract** — add DTOs in `libs/rpg-maestro-api-contract/src/lib/`
+   - Re-export from `index.ts`
+3. **DB entity** — implement interface in `infrastructure/persistence/in-memory/` AND `firestore/`
+   - Register in `DatabaseModule` and `DatabaseWrapperConfiguration`
+4. **Auth** — annotate controllers with `@UseGuards(JwtAuthGuard, RolesGuard)` + `@Roles([...])`
+5. **Frontend** — add API calls in `apps/rpg-maestro-ui/src/app/maestro-ui/maestro-api.ts`
+6. **Tests** — unit tests alongside source; E2E in `apps/rpg-maestro-ui-e2e/src/`
+7. **Update docs** — `docs/architecture.md` if the module changes system topology
+
+## Adding a New Route (Frontend)
+
+1. Create component in appropriate feature folder (`maestro-ui/`, `players-ui/`, etc.)
+2. Register route in `apps/rpg-maestro-ui/src/app/app.tsx`
+3. If auth-protected, wrap with `<PrivateRoute>` or `withAuthenticationRequired`
+4. Add to route table in `docs/architecture.md`
+
+## Nx Module Boundary Rules
+
+Tags in `project.json` enforce import boundaries via ESLint:
+
+| Tag | Meaning |
+|-----|---------|
+| `type:app` | Application |
+| `type:lib` | Shared library |
+| `type:e2e` | E2E test project |
+| `scope:backend` | Backend-only |
+| `scope:frontend` | Frontend-only |
+| `scope:shared` | Can be imported by both |
+
+Do not import a `scope:backend` library from a `scope:frontend` project.
+
+## Testing Patterns
+
+### Unit Tests (Vitest)
+
+```typescript
+// Backend — use real services with in-memory DB
+const databases = new DatabaseWrapperConfiguration('in-memory');
+const service = new TrackService(databases, ...);
+const result = await service.createTrack(sessionId, trackCreation);
+expect(result.name).toEqual('expected-name');
+```
+
+```typescript
+// Frontend — @testing-library/react
+render(<MyComponent />);
+await userEvent.click(screen.getByRole('button', { name: 'Play' }));
+expect(screen.getByText('Playing...')).toBeInTheDocument();
+```
+
+### E2E Tests (Playwright)
+
+```typescript
+// Setup: init fixtures via API
+const users = await initUsersFixtureSpec();
+const session = await generateNewSession(users.a_maestro_user);
+await iniTracksFromFileServerFixture(session, session.sessionId);
+
+// Auth: inject token into browser storage
+await simulateAuthenticatedInBrowser(page, session);
+
+// Navigate and assert
+await page.goto(`/maestro/${session.sessionId}`);
+await expect(page.locator('.MuiDataGrid-row')).toHaveCount(3);
+```
+
+## Common Pitfalls
+
+- **CORS errors**: `DEFAULT_FRONTEND_DOMAIN` must match the frontend origin exactly (no trailing slash)
+- **Auth failures in dev**: Check `isDevMode` in localStorage; backend must have fake IDP route active
+- **Firestore cold start**: `DATABASE=firestore` requires Firebase service account credentials (`GOOGLE_APPLICATION_CREDENTIALS` or env var)
+- **FFmpeg not found**: Install FFmpeg locally (`brew install ffmpeg`) or set `FFMPEG_PATH` / `FFPROBE_PATH`
+- **Nx cache stale**: Run `npx nx reset` to clear the Nx task cache
+- **E2E port conflicts**: E2E uses ports 8098/8099/4300; ensure nothing else binds those
+- **YouTube extraction**: `ytdl-core` occasionally breaks when YouTube changes their API — check for `@distube/ytdl-core` updates
+
+## Useful HTTP Examples
+
+See `apps/rpg-maestro/examples/SetupDevEnvironment.http` for ready-to-run API calls
+(compatible with the VS Code REST Client or IntelliJ HTTP client).


### PR DESCRIPTION
## Summary

- **`docs/architecture.md`** — Comprehensive system map: service topology diagram, NestJS module tree for both backends, pluggable DB abstraction (in-memory vs Firestore), Auth0 + fake-IDP auth flows, full API surface tables, real-time polling model, CI/CD pipeline, Docker images, and key ADRs.
- **`docs/dev-guide.md`** — Developer quick reference: startup commands, env file locations, new-feature checklist (module → contract → DB → auth → frontend → tests → docs), testing patterns for unit and E2E, route-addition steps, Nx module boundary rules, and common pitfalls.
- **`.claude/settings.json`** — Claude `Stop` hook that runs after each session. Checks `git diff --name-only HEAD` for changes to architecture-affecting files (NestJS modules, controllers, `app.tsx`, API contract libs, `database.module.ts`, `project.json`) and prints a reminder to update the docs if any are found. The hook fires only when relevant files change — not on every session.

## What's NOT included

- `settings.local.json` — already gitignored, untouched.
- No changes to application code.

## Test plan

- [ ] Confirm `docs/architecture.md` renders cleanly in GitHub (tables, ASCII diagram, code blocks)
- [ ] Confirm `docs/dev-guide.md` renders cleanly
- [ ] Locally: edit any `.module.ts` file, end the Claude session, verify the `[doc-hook]` message appears in Claude's output
- [ ] Verify hook does NOT fire when editing a non-architecture file (e.g. a spec file)