### PR TITLE
feat(ui): Space shortcut for play/pause + Help modal with keyboard reference

### DIFF
--- a/apps/rpg-maestro-ui/src/app/maestro-ui/maestro-audio-player/maestro-audio-player.tsx
+++ b/apps/rpg-maestro-ui/src/app/maestro-ui/maestro-audio-player/maestro-audio-player.tsx
@@ -9,6 +9,7 @@ import { AbortedRequestError } from '../maestro-api';
 
 export interface MaestroAudioPlayerRef {
   dispatchTrackWasManuallyChanged: (newTracks: SessionPlayingTracks) => void;
+  togglePlayPause: () => Promise<void>;
   currentTrack: PlayingTrack | null;
 }
 
@@ -28,10 +29,6 @@ export const MaestroAudioPlayer = forwardRef((props: MaestroAudioPlayerProps, re
   const dispatchTrackWasManuallyChanged = (newTracks: SessionPlayingTracks) => {
     resyncCurrentTrackOnUi(newTracks.currentTrack);
   };
-  useImperativeHandle(ref, () => ({
-    dispatchTrackWasManuallyChanged,
-    currentTrack: currentTrack
-  }));
 
   if (audioPlayer.current?.progressBar.current) {
     audioPlayer.current.progressBar.current.onclick = (e) => {
@@ -141,6 +138,16 @@ export const MaestroAudioPlayer = forwardRef((props: MaestroAudioPlayerProps, re
     }, SYNC_TRACK_INTERVAL_MS);
     return () => clearInterval(id);
   }, [periodicallySyncCurrentTrack, sessionId, currentTrack]);
+
+  const togglePlayPause = async (): Promise<void> => {
+    if (!currentTrack) return;
+    await changePlayingStatus(currentTrack.isPaused);
+  };
+  useImperativeHandle(ref, () => ({
+    dispatchTrackWasManuallyChanged,
+    togglePlayPause,
+    currentTrack: currentTrack,
+  }));
 
   const changePlayingStatus = async (playing: boolean): Promise<void> => {
       if (!currentTrack) {

--- a/apps/rpg-maestro-ui/src/app/maestro-ui/maestro-audio-player/maestro-audio-player.tsx
+++ b/apps/rpg-maestro-ui/src/app/maestro-ui/maestro-audio-player/maestro-audio-player.tsx
@@ -139,14 +139,13 @@ export const MaestroAudioPlayer = forwardRef((props: MaestroAudioPlayerProps, re
     return () => clearInterval(id);
   }, [periodicallySyncCurrentTrack, sessionId, currentTrack]);
 
-  const togglePlayPause = async (): Promise<void> => {
-    if (!currentTrack) return;
-    await changePlayingStatus(currentTrack.isPaused);
-  };
   useImperativeHandle(ref, () => ({
     dispatchTrackWasManuallyChanged,
-    togglePlayPause,
-    currentTrack: currentTrack,
+    togglePlayPause: async () => {
+      if (!currentTrack) return;
+      await changePlayingStatus(currentTrack.isPaused);
+    },
+    currentTrack,
   }));
 
   const changePlayingStatus = async (playing: boolean): Promise<void> => {

--- a/apps/rpg-maestro-ui/src/app/maestro-ui/maestro-soundboard.tsx
+++ b/apps/rpg-maestro-ui/src/app/maestro-ui/maestro-soundboard.tsx
@@ -24,12 +24,14 @@ import { withAuthenticationRequired } from '@auth0/auth0-react';
 import { Loading } from '../auth/Loading';
 import { isDevModeEnabled } from '../../FeaturesConfiguration';
 import { Soundboard } from './soundboard/soundboard';
+import HelpModal from '../ui-components/help-modal';
 
 function MaestroSoundboardComponent() {
   const [user, setUser] = useState<User | undefined>(undefined);
   const [allTracks, setAllTracks] = useState<Track[] | undefined>(undefined);
   const [soundboardTracks, setSoundboardTracks] = useState<Track[] | undefined>(undefined);
   const [trackFilters, setTrackFilters] = useState<TrackFilters>({ excludeTags: ['soundboard'] });
+  const [helpOpen, setHelpOpen] = useState(false);
   const sessionId = useParams().sessionId ?? '';
   if (sessionId === '') {
     displayError('no session found in URL (it should be https://{URL}/maestro/{sessionId})');
@@ -60,6 +62,18 @@ function MaestroSoundboardComponent() {
       });
     }
   });
+
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.target instanceof HTMLInputElement || e.target instanceof HTMLTextAreaElement) return;
+      if (e.code === 'Space') {
+        e.preventDefault();
+        maestroAudioPlayerChildRef.current?.togglePlayPause();
+      }
+    };
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, []);
 
   const refreshTracks = () => {
     getAllTracks(sessionId).then((x) => setAllTracks(x));
@@ -154,7 +168,7 @@ function MaestroSoundboardComponent() {
         <div>
           <div style={{ display: 'flex', gap: '2rem' }}>
             <h1 style={{ marginTop: 0 }}>Maestro UI</h1>
-            <BasicMenu />
+            <BasicMenu onHelpClick={() => setHelpOpen(true)} />
           </div>
           <p>As the Maestro, control what current track is playing for the session: {sessionId}</p>
           <p>
@@ -270,6 +284,7 @@ function MaestroSoundboardComponent() {
       </div>
       <audio ref={effectAudioRef} style={{ display: 'none' }} />
       <ToastContainer limit={5} />
+      <HelpModal open={helpOpen} onClose={() => setHelpOpen(false)} />
     </div>
   );
 }

--- a/apps/rpg-maestro-ui/src/app/maestro-ui/maestro-soundboard.tsx
+++ b/apps/rpg-maestro-ui/src/app/maestro-ui/maestro-soundboard.tsx
@@ -65,7 +65,13 @@ function MaestroSoundboardComponent() {
 
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.target instanceof HTMLInputElement || e.target instanceof HTMLTextAreaElement) return;
+      const target = e.target as HTMLElement;
+      if (
+        target instanceof HTMLInputElement ||
+        target instanceof HTMLTextAreaElement ||
+        target.isContentEditable ||
+        target.closest('[role="dialog"]') !== null
+      ) return;
       if (e.code === 'Space') {
         e.preventDefault();
         maestroAudioPlayerChildRef.current?.togglePlayPause();

--- a/apps/rpg-maestro-ui/src/app/ui-components/help-modal.tsx
+++ b/apps/rpg-maestro-ui/src/app/ui-components/help-modal.tsx
@@ -1,0 +1,54 @@
+import * as React from 'react';
+import Dialog from '@mui/material/Dialog';
+import DialogTitle from '@mui/material/DialogTitle';
+import DialogContent from '@mui/material/DialogContent';
+import DialogActions from '@mui/material/DialogActions';
+import Button from '@mui/material/Button';
+import Table from '@mui/material/Table';
+import TableBody from '@mui/material/TableBody';
+import TableCell from '@mui/material/TableCell';
+import TableHead from '@mui/material/TableHead';
+import TableRow from '@mui/material/TableRow';
+import Kbd from './kbd';
+
+interface HelpModalProps {
+  open: boolean;
+  onClose: () => void;
+}
+
+const SHORTCUTS = [
+  { key: 'Space', description: 'Play / Pause current track' },
+];
+
+export default function HelpModal({ open, onClose }: HelpModalProps) {
+  return (
+    <Dialog open={open} onClose={onClose} maxWidth="sm" fullWidth>
+      <DialogTitle>Keyboard Shortcuts</DialogTitle>
+      <DialogContent>
+        <Table size="small">
+          <TableHead>
+            <TableRow>
+              <TableCell>Key</TableCell>
+              <TableCell>Action</TableCell>
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {SHORTCUTS.map(({ key, description }) => (
+              <TableRow key={key}>
+                <TableCell>
+                  <Kbd>{key}</Kbd>
+                </TableCell>
+                <TableCell>{description}</TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose} color="secondary">
+          Close
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/apps/rpg-maestro-ui/src/app/ui-components/kbd.tsx
+++ b/apps/rpg-maestro-ui/src/app/ui-components/kbd.tsx
@@ -1,0 +1,20 @@
+import * as React from 'react';
+
+export default function Kbd({ children }: { children: React.ReactNode }) {
+  return (
+    <kbd
+      style={{
+        display: 'inline-block',
+        padding: '2px 8px',
+        borderRadius: '4px',
+        border: '1px solid var(--gold-color, #b8960c)',
+        fontFamily: 'monospace',
+        fontSize: '0.85em',
+        background: 'rgba(255,255,255,0.05)',
+        color: 'var(--gold-color, #b8960c)',
+      }}
+    >
+      {children}
+    </kbd>
+  );
+}

--- a/apps/rpg-maestro-ui/src/app/ui-components/menu.tsx
+++ b/apps/rpg-maestro-ui/src/app/ui-components/menu.tsx
@@ -5,7 +5,11 @@ import MenuItem from '@mui/material/MenuItem';
 import { useNavigate } from 'react-router-dom';
 import { useAuth0 } from '@auth0/auth0-react';
 
-export default function BasicMenu() {
+interface BasicMenuProps {
+  onHelpClick?: () => void;
+}
+
+export default function BasicMenu({ onHelpClick }: BasicMenuProps) {
   const navigate = useNavigate();
   const [anchorEl, setAnchorEl] = React.useState<null | HTMLElement>(null);
   const open = Boolean(anchorEl);
@@ -40,6 +44,16 @@ export default function BasicMenu() {
           },
         }}
       >
+        {onHelpClick && (
+          <MenuItem
+            onClick={() => {
+              handleClose();
+              onHelpClick();
+            }}
+          >
+            Help / Keyboard shortcuts
+          </MenuItem>
+        )}
         <MenuItem onClick={() => navigate('/maestro/infos')}>My account</MenuItem>
         <MenuItem
           onClick={() => logout({ logoutParams: { returnTo: window.location.origin } })}


### PR DESCRIPTION
## Summary

- **Space bar** toggles play/pause on the maestro soundboard; ignored when an input/textarea has focus
- **Help / Keyboard shortcuts** menu item added to the main Menu — opens a dialog listing all available shortcuts
- New `Kbd` component for styled keyboard key display (gold-themed, consistent with the app palette)

## Changes

- `maestro-audio-player.tsx` — exposes `togglePlayPause()` on the player ref
- `maestro-soundboard.tsx` — `keydown` listener wired to the player ref; `HelpModal` state managed here
- `menu.tsx` — accepts optional `onHelpClick` prop, renders Help item when provided
- `help-modal.tsx` (new) — MUI Dialog with a shortcuts table
- `kbd.tsx` (new) — styled `<kbd>` element

## Test plan

- [ ] Open the maestro soundboard, start a track, press Space — track pauses
- [ ] Press Space again — track resumes
- [ ] Click into a search input, press Space — no pause/resume (input gets the character instead)
- [ ] Open Menu → "Help / Keyboard shortcuts" — dialog appears with the Space shortcut listed
- [ ] Close the dialog via the Close button or clicking outside