### PR TITLE
fix(api): round track duration to integer milliseconds

### DIFF
--- a/apps/rpg-maestro/src/app/maestro-api/audio/AudioHelper.spec.ts
+++ b/apps/rpg-maestro/src/app/maestro-api/audio/AudioHelper.spec.ts
@@ -1,0 +1,21 @@
+import { describe, it, expect } from 'vitest';
+import { toDurationInMs } from './AudioHelper';
+
+describe('toDurationInMs', () => {
+  it('converts whole seconds to milliseconds', () => {
+    expect(toDurationInMs(121)).toBe(121000);
+  });
+
+  it('returns an integer number of milliseconds when the probed duration has decimals', () => {
+    // ffprobe reports fractional seconds, e.g. 50.717211s -> 50717.211ms before rounding (see issue #37)
+    const durationInMs = toDurationInMs(50.717211);
+
+    expect(Number.isInteger(durationInMs)).toBe(true);
+    expect(durationInMs).toBe(50717);
+  });
+
+  it('rounds to the nearest millisecond', () => {
+    expect(toDurationInMs(1.4885)).toBe(1489);
+    expect(toDurationInMs(1.4884)).toBe(1488);
+  });
+});

--- a/apps/rpg-maestro/src/app/maestro-api/audio/AudioHelper.ts
+++ b/apps/rpg-maestro/src/app/maestro-api/audio/AudioHelper.ts
@@ -1,5 +1,12 @@
 import ffmpeg from 'fluent-ffmpeg';
 
+// ffprobe reports the duration in (possibly fractional) seconds. Tracks store the duration as an
+// integer number of milliseconds, so round to avoid values like 50717.210999999996 that would leak
+// floating-point noise into playback sync calculations.
+export function toDurationInMs(durationInSeconds: number): number {
+  return Math.round(durationInSeconds * 1000);
+}
+
 export async function getTrackDuration(url: URL): Promise<number> {
   return new Promise((resolve, reject) => {
     ffmpeg.ffprobe(url.toString(), (err, metadata) => {
@@ -7,7 +14,7 @@ export async function getTrackDuration(url: URL): Promise<number> {
         reject(err);
         return;
       }
-      resolve(metadata.format.duration * 1000);
+      resolve(toDurationInMs(metadata.format.duration));
     });
   });
 }


### PR DESCRIPTION
## Problem

Fixes #37. Some tracks had durations like `50717.210999999996`.

`AudioHelper.getTrackDuration` did `metadata.format.duration * 1000`, but `ffprobe` reports duration in **fractional seconds** — so multiplying by 1000 produced a float with a long decimal tail. Durations are meant to be an integer number of milliseconds, and `PlayingTrack.getCurrentPlayTime()` uses `% duration` for playback sync, so the float noise fed directly into the sync math.

## Fix

Extract a pure `toDurationInMs()` that rounds to the nearest millisecond, and have `getTrackDuration` delegate to it. This is the single source point — both `TrackService.createTrack` and the track-collection service resolve durations via `getTrackFileMetadata -> getTrackDuration`, so every ingestion path is covered.

## Tests (TDD)

Added `AudioHelper.spec.ts` unit-testing `toDurationInMs`: whole seconds, fractional seconds → integer ms (the issue's case), and nearest-ms rounding. Wrote the failing test first, then the fix. Full `rpg-maestro` suite green (35 tests), lint + prettier clean.

## Note

Fixes newly ingested tracks. Any already-persisted tracks with decimal durations (prod Firestore) would need a one-off data migration — out of scope here.