### PR TITLE
feat(ui): voice-driven track selection via microphone (dev-only)

### DIFF
--- a/apps/rpg-maestro-ui/src/app/maestro-ui/maestro-soundboard.tsx
+++ b/apps/rpg-maestro-ui/src/app/maestro-ui/maestro-soundboard.tsx
@@ -1,5 +1,5 @@
 import { filter, TrackFilters, TracksTable } from './tracks-table/tracks-table';
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { SessionPlayingTracks, Tag, Track, TrackToPlay, User } from '@rpg-maestro/rpg-maestro-api-contract';
 import { AbortedRequestError, getAllTracks, getSoundboardTracks, setTrackToPlay } from './maestro-api';
 import { ToastContainer } from 'react-toastify';
@@ -18,13 +18,16 @@ import { useParams } from 'react-router';
 import { ContentToCopy } from '../ui-components/content-to-copy/content-to-copy';
 import { MaestroAudioPlayer, MaestroAudioPlayerRef } from './maestro-audio-player/maestro-audio-player';
 import { getUser } from '../cache/user.cache';
-import { toastError } from '../ui-components/toast-popup';
+import { toastError, toastInfo } from '../ui-components/toast-popup';
 import BasicMenu from '../ui-components/menu';
 import { withAuthenticationRequired } from '@auth0/auth0-react';
 import { Loading } from '../auth/Loading';
 import { isDevModeEnabled } from '../../FeaturesConfiguration';
 import { Soundboard } from './soundboard/soundboard';
 import HelpModal from '../ui-components/help-modal';
+import { MicrophoneTrackButton } from './voice-track-selection/microphone-track-button';
+import { VoiceSelectionResult } from './voice-track-selection/use-voice-track-selection';
+import { collectAvailableTags, pickBestMatchingTrack } from './voice-track-selection/track-matching';
 
 function MaestroSoundboardComponent() {
   const [user, setUser] = useState<User | undefined>(undefined);
@@ -142,6 +145,20 @@ function MaestroSoundboardComponent() {
     });
     await requestRandomTrackToPlay(tags);
   };
+  const availableTags = useMemo(() => collectAvailableTags(allTracks ?? []), [allTracks]);
+  const onVoiceTrackSelection = async ({ tags, transcript }: VoiceSelectionResult) => {
+    if (tags.length === 0) {
+      toastInfo(`Heard "${transcript}" but found no matching tags.`, 4000);
+      return;
+    }
+    setTrackFilters({ ...trackFilters, tagsToFilterOn: tags });
+    const bestMatch = pickBestMatchingTrack(allTracks ?? [], tags, { excludeTrackId: currentPlayingTrack?.id });
+    if (!bestMatch) {
+      toastInfo(`No track matches: ${tags.join(', ')}.`, 4000);
+      return;
+    }
+    await requestSetTrackToPlay(bestMatch.id);
+  };
   const requestRandomTrackToPlay = async (tags: Tag[]) => {
     if (allTracks) {
       const filtered = filter(
@@ -219,6 +236,7 @@ function MaestroSoundboardComponent() {
           <div
             style={{ display: 'flex', flexDirection: 'row', flexWrap: 'wrap', justifyContent: 'center', margin: '0' }}
           >
+            <MicrophoneTrackButton availableTags={availableTags} onResult={onVoiceTrackSelection} />
             <QuickTagSelection
               text={'combat'}
               icon={ShieldIcon}

--- a/apps/rpg-maestro-ui/src/app/maestro-ui/maestro-soundboard.tsx
+++ b/apps/rpg-maestro-ui/src/app/maestro-ui/maestro-soundboard.tsx
@@ -236,7 +236,11 @@ function MaestroSoundboardComponent() {
           <div
             style={{ display: 'flex', flexDirection: 'row', flexWrap: 'wrap', justifyContent: 'center', margin: '0' }}
           >
-            <MicrophoneTrackButton availableTags={availableTags} onResult={onVoiceTrackSelection} />
+            <MicrophoneTrackButton
+              availableTags={availableTags}
+              onResult={onVoiceTrackSelection}
+              isAdmin={user?.role === 'ADMIN'}
+            />
             <QuickTagSelection
               text={'combat'}
               icon={ShieldIcon}

--- a/apps/rpg-maestro-ui/src/app/maestro-ui/voice-track-selection/interpretation/interpretation-provider-registry.ts
+++ b/apps/rpg-maestro-ui/src/app/maestro-ui/voice-track-selection/interpretation/interpretation-provider-registry.ts
@@ -1,0 +1,17 @@
+import { TagInterpretationProvider } from './tag-interpretation-provider';
+import { PatternMatchingInterpretationProvider } from './pattern-matching-interpretation-provider';
+
+/**
+ * Ordered list of known interpretation providers, most-preferred first.
+ * Add future providers (e.g. a real LLM-backed provider) here.
+ */
+export function getInterpretationProviders(): TagInterpretationProvider[] {
+  return [new PatternMatchingInterpretationProvider()];
+}
+
+/** Returns the preferred interpretation provider. There is always at least one. */
+export function resolveInterpretationProvider(
+  providers: TagInterpretationProvider[] = getInterpretationProviders()
+): TagInterpretationProvider {
+  return providers[0];
+}

--- a/apps/rpg-maestro-ui/src/app/maestro-ui/voice-track-selection/interpretation/pattern-matching-interpretation-provider.spec.ts
+++ b/apps/rpg-maestro-ui/src/app/maestro-ui/voice-track-selection/interpretation/pattern-matching-interpretation-provider.spec.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest';
+import { PatternMatchingInterpretationProvider } from './pattern-matching-interpretation-provider';
+
+describe('PatternMatchingInterpretationProvider', () => {
+  const provider = new PatternMatchingInterpretationProvider();
+  const availableTags = ['combat', 'settlement', 'forest', 'travel', 'dungeon'];
+
+  it('maps combat keywords (sword, bow) to the combat tag', async () => {
+    const result = await provider.interpret({
+      transcript: 'The orc raises his sword and the ranger draws her bow!',
+      availableTags,
+    });
+    expect(result.tags).toEqual(['combat']);
+    expect(result.provider).toBe('pattern-matching');
+  });
+
+  it('matches multiple distinct scenes in one transcript', async () => {
+    const result = await provider.interpret({
+      transcript: 'You leave the village and travel through the dark forest.',
+      availableTags,
+    });
+    expect(result.tags).toContain('settlement');
+    expect(result.tags).toContain('travel');
+    expect(result.tags).toContain('forest');
+  });
+
+  it('only returns tags that exist in the session', async () => {
+    const result = await provider.interpret({
+      transcript: 'A goblin ambush in the woods!',
+      availableTags: ['combat'], // forest is intentionally absent
+    });
+    expect(result.tags).toEqual(['combat']);
+  });
+
+  it('matches when the transcript literally names an available tag', async () => {
+    const result = await provider.interpret({
+      transcript: 'Switch to something more mystery themed.',
+      availableTags: ['combat', 'mystery'],
+    });
+    expect(result.tags).toEqual(['mystery']);
+  });
+
+  it('does not match keywords embedded inside larger words', async () => {
+    const result = await provider.interpret({
+      transcript: 'The swordfish swam past the crown.',
+      availableTags,
+    });
+    expect(result.tags).toEqual([]);
+  });
+
+  it('returns no tags when nothing matches', async () => {
+    const result = await provider.interpret({
+      transcript: 'Everyone sits quietly and reads a book.',
+      availableTags,
+    });
+    expect(result.tags).toEqual([]);
+  });
+});

--- a/apps/rpg-maestro-ui/src/app/maestro-ui/voice-track-selection/interpretation/pattern-matching-interpretation-provider.ts
+++ b/apps/rpg-maestro-ui/src/app/maestro-ui/voice-track-selection/interpretation/pattern-matching-interpretation-provider.ts
@@ -1,0 +1,105 @@
+import { Tag } from '@rpg-maestro/rpg-maestro-api-contract';
+import {
+  TagInterpretationInput,
+  TagInterpretationProvider,
+  TagInterpretationResult,
+} from './tag-interpretation-provider';
+
+/**
+ * Maps a canonical mood/scene tag to the spoken keywords that should trigger it.
+ * Keys mirror the quick-tags used elsewhere in the soundboard (combat, settlement,
+ * forest, travel, dungeon) plus a few extras. Multi-word keywords are matched as
+ * whole phrases; single-word keywords are matched on word boundaries.
+ */
+export const DEFAULT_TAG_PATTERNS: Record<string, string[]> = {
+  combat: [
+    'sword',
+    'bow',
+    'arrow',
+    'attack',
+    'fight',
+    'fighting',
+    'battle',
+    'enemy',
+    'enemies',
+    'goblin',
+    'orc',
+    'dragon',
+    'initiative',
+    'hit',
+    'strike',
+    'slay',
+    'ambush',
+    'duel',
+  ],
+  settlement: ['town', 'village', 'city', 'market', 'shop', 'merchant', 'street', 'gate', 'citizen'],
+  tavern: ['tavern', 'inn', 'ale', 'drink', 'bard', 'feast', 'barkeep'],
+  forest: ['forest', 'woods', 'wood', 'tree', 'trees', 'jungle', 'grove', 'wilderness'],
+  travel: ['travel', 'journey', 'road', 'path', 'walk', 'march', 'ride', 'horse', 'wagon', 'trek'],
+  dungeon: ['dungeon', 'cave', 'crypt', 'tomb', 'catacomb', 'underground', 'ruins', 'cellar', 'labyrinth'],
+  mystery: ['mystery', 'clue', 'investigate', 'secret', 'riddle', 'puzzle', 'strange'],
+};
+
+/**
+ * Deterministic, LLM-free interpreter. It looks for known keywords in the transcript
+ * to derive canonical mood tags, then intersects the result with the session's actual
+ * available tags so only real, playable tags are ever returned. It also matches when
+ * the transcript literally mentions an available tag by name.
+ *
+ * This is the first-iteration stand-in for a real LLM provider; it deliberately shares
+ * the {@link TagInterpretationProvider} contract so it can be swapped out transparently.
+ */
+export class PatternMatchingInterpretationProvider implements TagInterpretationProvider {
+  readonly name = 'pattern-matching';
+
+  constructor(private readonly patterns: Record<string, string[]> = DEFAULT_TAG_PATTERNS) {}
+
+  interpret({ transcript, availableTags }: TagInterpretationInput): Promise<TagInterpretationResult> {
+    const normalized = normalizeForMatching(transcript);
+    const availableByLower = new Map<string, Tag>();
+    for (const tag of availableTags) {
+      availableByLower.set(tag.toLowerCase(), tag);
+    }
+
+    const matched = new Set<Tag>();
+
+    // 1. Canonical mood tags derived from keyword patterns.
+    for (const [canonicalTag, keywords] of Object.entries(this.patterns)) {
+      const availableTag = availableByLower.get(canonicalTag.toLowerCase());
+      if (!availableTag) {
+        continue; // this session has no such tag — skip it
+      }
+      if (keywords.some((keyword) => phraseAppears(normalized, keyword))) {
+        matched.add(availableTag);
+      }
+    }
+
+    // 2. Any available tag whose own name is spoken in the transcript.
+    for (const [lowerTag, tag] of availableByLower) {
+      if (phraseAppears(normalized, lowerTag)) {
+        matched.add(tag);
+      }
+    }
+
+    return Promise.resolve({ tags: [...matched], provider: this.name });
+  }
+}
+
+/** Lower-cases, strips punctuation, and pads with spaces so phrase lookups are simple. */
+function normalizeForMatching(text: string): string {
+  const cleaned = text
+    .toLowerCase()
+    .replace(/[^a-z0-9\s]/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+  return ` ${cleaned} `;
+}
+
+/** True if `phrase` appears as a whole word / phrase in the already-normalized text. */
+function phraseAppears(normalizedText: string, phrase: string): boolean {
+  const normalizedPhrase = phrase.toLowerCase().replace(/\s+/g, ' ').trim();
+  if (normalizedPhrase === '') {
+    return false;
+  }
+  return normalizedText.includes(` ${normalizedPhrase} `);
+}

--- a/apps/rpg-maestro-ui/src/app/maestro-ui/voice-track-selection/interpretation/tag-interpretation-prompt.ts
+++ b/apps/rpg-maestro-ui/src/app/maestro-ui/voice-track-selection/interpretation/tag-interpretation-prompt.ts
@@ -1,0 +1,26 @@
+import { Tag } from '@rpg-maestro/rpg-maestro-api-contract';
+
+/**
+ * Builds the LLM prompt from the two inputs the feature is specified around:
+ * the spoken transcript and the list of tags available in the session.
+ *
+ * The current first-iteration provider is a deterministic pattern matcher that does
+ * not call an LLM, but a future real-LLM provider is expected to send this exact prompt
+ * and parse a JSON array of tags back. Keeping the prompt here means the "what we would
+ * ask the model" contract lives in one place, independent of any provider.
+ */
+export function buildTagInterpretationPrompt(transcript: string, availableTags: Tag[]): string {
+  return [
+    'You are helping a tabletop RPG game master pick background music.',
+    'Given a short transcript of what is happening at the table and the list of available music tags,',
+    'choose the tags that best match the mood and scene.',
+    '',
+    'Rules:',
+    '- Only return tags from the provided list of available tags.',
+    '- Return between 1 and 3 tags, ordered from most to least relevant.',
+    '- Respond with a JSON array of strings and nothing else.',
+    '',
+    `Available tags: ${JSON.stringify(availableTags)}`,
+    `Transcript: ${JSON.stringify(transcript)}`,
+  ].join('\n');
+}

--- a/apps/rpg-maestro-ui/src/app/maestro-ui/voice-track-selection/interpretation/tag-interpretation-provider.ts
+++ b/apps/rpg-maestro-ui/src/app/maestro-ui/voice-track-selection/interpretation/tag-interpretation-provider.ts
@@ -1,0 +1,32 @@
+import { Tag } from '@rpg-maestro/rpg-maestro-api-contract';
+
+/**
+ * Provider-agnostic contract for turning a spoken transcript into a list of track tags
+ * to play, given the tags actually available in the current session.
+ *
+ * The first concrete implementation is a deterministic keyword matcher
+ * ({@link PatternMatchingInterpretationProvider}) standing in for a real LLM. Future
+ * providers (e.g. an actual LLM call built from {@link buildTagInterpretationPrompt})
+ * implement the same interface and can be swapped in via the registry.
+ */
+
+export interface TagInterpretationInput {
+  /** The transcript of what the maestro said. */
+  transcript: string;
+  /** Every tag that exists across the session's tracks — the allowed output vocabulary. */
+  availableTags: Tag[];
+}
+
+export interface TagInterpretationResult {
+  /** Tags to play, all guaranteed to be members of `availableTags`. */
+  tags: Tag[];
+  /** Name of the provider that produced this result. */
+  provider: string;
+}
+
+export interface TagInterpretationProvider {
+  /** Stable identifier used in logs and results. */
+  readonly name: string;
+  /** Map a transcript + available tags to the subset of tags that should play. */
+  interpret(input: TagInterpretationInput): Promise<TagInterpretationResult>;
+}

--- a/apps/rpg-maestro-ui/src/app/maestro-ui/voice-track-selection/microphone-track-button.spec.tsx
+++ b/apps/rpg-maestro-ui/src/app/maestro-ui/voice-track-selection/microphone-track-button.spec.tsx
@@ -1,0 +1,53 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { vi } from 'vitest';
+import { MicrophoneTrackButton } from './microphone-track-button';
+import { UseVoiceTrackSelection } from './use-voice-track-selection';
+
+const hookMock = vi.hoisted(() => ({ useVoiceTrackSelection: vi.fn() }));
+
+vi.mock('./use-voice-track-selection', () => ({
+  useVoiceTrackSelection: hookMock.useVoiceTrackSelection,
+}));
+
+// NODE_ENV is 'test' during vitest runs, so isDevModeEnabled is true here — the button
+// is gated only by provider support, which is what these tests exercise.
+function mockHook(overrides: Partial<UseVoiceTrackSelection>): void {
+  hookMock.useVoiceTrackSelection.mockReturnValue({
+    status: 'idle',
+    partialTranscript: '',
+    isSupported: true,
+    start: vi.fn(),
+    ...overrides,
+  });
+}
+
+describe('MicrophoneTrackButton', () => {
+  it('is enabled and calls start when clicked in a supported environment', () => {
+    const start = vi.fn();
+    mockHook({ isSupported: true, start });
+    render(<MicrophoneTrackButton availableTags={['combat']} onResult={vi.fn()} />);
+
+    const button = screen.getByRole('button', { name: /listen and pick a matching track/i });
+    expect((button as HTMLButtonElement).disabled).toBe(false);
+    fireEvent.click(button);
+    expect(start).toHaveBeenCalledTimes(1);
+  });
+
+  it('is disabled when no transcription provider is supported', () => {
+    mockHook({ isSupported: false });
+    render(<MicrophoneTrackButton availableTags={['combat']} onResult={vi.fn()} />);
+
+    const button = screen.getByRole('button', { name: /listen and pick a matching track/i });
+    expect((button as HTMLButtonElement).disabled).toBe(true);
+  });
+
+  it('is disabled while a selection is in progress', () => {
+    const start = vi.fn();
+    mockHook({ status: 'listening', start });
+    render(<MicrophoneTrackButton availableTags={['combat']} onResult={vi.fn()} />);
+
+    const button = screen.getByRole('button', { name: /listen and pick a matching track/i });
+    expect((button as HTMLButtonElement).disabled).toBe(true);
+    expect(screen.getByText('listening…')).toBeTruthy();
+  });
+});

--- a/apps/rpg-maestro-ui/src/app/maestro-ui/voice-track-selection/microphone-track-button.spec.tsx
+++ b/apps/rpg-maestro-ui/src/app/maestro-ui/voice-track-selection/microphone-track-button.spec.tsx
@@ -9,8 +9,6 @@ vi.mock('./use-voice-track-selection', () => ({
   useVoiceTrackSelection: hookMock.useVoiceTrackSelection,
 }));
 
-// NODE_ENV is 'test' during vitest runs, so isDevModeEnabled is true here — the button
-// is gated only by provider support, which is what these tests exercise.
 function mockHook(overrides: Partial<UseVoiceTrackSelection>): void {
   hookMock.useVoiceTrackSelection.mockReturnValue({
     status: 'idle',
@@ -22,10 +20,19 @@ function mockHook(overrides: Partial<UseVoiceTrackSelection>): void {
 }
 
 describe('MicrophoneTrackButton', () => {
-  it('is enabled and calls start when clicked in a supported environment', () => {
+  it('renders nothing for non-admin users', () => {
+    mockHook({ isSupported: true });
+    const { container } = render(
+      <MicrophoneTrackButton availableTags={['combat']} onResult={vi.fn()} isAdmin={false} />
+    );
+    expect(container.firstChild).toBeNull();
+    expect(screen.queryByRole('button')).toBeNull();
+  });
+
+  it('is enabled for an admin and calls start when clicked in a supported environment', () => {
     const start = vi.fn();
     mockHook({ isSupported: true, start });
-    render(<MicrophoneTrackButton availableTags={['combat']} onResult={vi.fn()} />);
+    render(<MicrophoneTrackButton availableTags={['combat']} onResult={vi.fn()} isAdmin={true} />);
 
     const button = screen.getByRole('button', { name: /listen and pick a matching track/i });
     expect((button as HTMLButtonElement).disabled).toBe(false);
@@ -33,9 +40,9 @@ describe('MicrophoneTrackButton', () => {
     expect(start).toHaveBeenCalledTimes(1);
   });
 
-  it('is disabled when no transcription provider is supported', () => {
+  it('is disabled for an admin when no transcription provider is supported', () => {
     mockHook({ isSupported: false });
-    render(<MicrophoneTrackButton availableTags={['combat']} onResult={vi.fn()} />);
+    render(<MicrophoneTrackButton availableTags={['combat']} onResult={vi.fn()} isAdmin={true} />);
 
     const button = screen.getByRole('button', { name: /listen and pick a matching track/i });
     expect((button as HTMLButtonElement).disabled).toBe(true);
@@ -44,7 +51,7 @@ describe('MicrophoneTrackButton', () => {
   it('is disabled while a selection is in progress', () => {
     const start = vi.fn();
     mockHook({ status: 'listening', start });
-    render(<MicrophoneTrackButton availableTags={['combat']} onResult={vi.fn()} />);
+    render(<MicrophoneTrackButton availableTags={['combat']} onResult={vi.fn()} isAdmin={true} />);
 
     const button = screen.getByRole('button', { name: /listen and pick a matching track/i });
     expect((button as HTMLButtonElement).disabled).toBe(true);

--- a/apps/rpg-maestro-ui/src/app/maestro-ui/voice-track-selection/microphone-track-button.tsx
+++ b/apps/rpg-maestro-ui/src/app/maestro-ui/voice-track-selection/microphone-track-button.tsx
@@ -1,0 +1,93 @@
+import React from 'react';
+import Button from '@mui/material/Button';
+import Tooltip from '@mui/material/Tooltip';
+import CircularProgress from '@mui/material/CircularProgress';
+import MicIcon from '@mui/icons-material/Mic';
+import { Tag } from '@rpg-maestro/rpg-maestro-api-contract';
+import { isDevModeEnabled } from '../../../FeaturesConfiguration';
+import { useVoiceTrackSelection, VoiceSelectionResult } from './use-voice-track-selection';
+
+export interface MicrophoneTrackButtonProps {
+  /** Tags available in the session — the interpreter's allowed output vocabulary. */
+  availableTags: Tag[];
+  /** Called with the tags (and transcript) derived from the spoken audio. */
+  onResult: (result: VoiceSelectionResult) => void;
+  /** Overrides how long the microphone listens. */
+  listeningDurationMs?: number;
+}
+
+const BUTTON_LABEL: Record<'idle' | 'listening' | 'interpreting', string> = {
+  idle: 'listen',
+  listening: 'listening…',
+  interpreting: 'thinking…',
+};
+
+/**
+ * Microphone button that listens to the maestro, transcribes what is said, and asks
+ * the interpretation layer which tags to play. The feature is experimental, so the
+ * button is only enabled in the dev environment (and only when a transcription
+ * provider is available); elsewhere it is rendered disabled with an explanatory tooltip.
+ */
+export function MicrophoneTrackButton({ availableTags, onResult, listeningDurationMs }: MicrophoneTrackButtonProps) {
+  const { status, partialTranscript, isSupported, start } = useVoiceTrackSelection({
+    availableTags,
+    onResult,
+    listeningDurationMs,
+  });
+
+  const isBusy = status !== 'idle';
+  const enabled = isDevModeEnabled && isSupported && !isBusy;
+
+  const disabledReason = !isDevModeEnabled
+    ? 'Voice track selection is only available in the development environment'
+    : !isSupported
+      ? 'Your browser does not support speech recognition (try Chrome or Edge)'
+      : '';
+
+  const tooltipTitle =
+    status === 'listening' && partialTranscript !== ''
+      ? partialTranscript
+      : disabledReason || 'Listen and pick a track that matches the scene';
+
+  return (
+    <Tooltip title={tooltipTitle} placement="top" arrow>
+      {/* span wrapper keeps the tooltip working while the button is disabled */}
+      <span>
+        <Button
+          onClick={start}
+          disabled={!enabled}
+          aria-label="Listen and pick a matching track"
+          sx={{
+            display: 'flex',
+            flexDirection: 'column',
+            gap: '2px',
+            color: status === 'listening' ? '#d64545' : 'var(--gold-color)',
+            height: '60px',
+            width: '110px',
+            border: '1px solid',
+            fontSize: '11px',
+            fontWeight: '500',
+            backgroundColor: 'rgba(57,57,57,0.15)',
+            '@keyframes voice-pulse': {
+              '0%': { transform: 'scale(1)', opacity: 1 },
+              '50%': { transform: 'scale(1.15)', opacity: 0.6 },
+              '100%': { transform: 'scale(1)', opacity: 1 },
+            },
+          }}
+        >
+          {status === 'interpreting' ? (
+            <CircularProgress size={28} sx={{ color: 'var(--gold-color)' }} />
+          ) : (
+            <MicIcon
+              sx={{
+                fontSize: 30,
+                animation: status === 'listening' ? 'voice-pulse 1.2s ease-in-out infinite' : 'none',
+              }}
+            />
+          )}
+          <span>{BUTTON_LABEL[status]}</span>
+        </Button>
+      </span>
+    </Tooltip>
+  );
+}

--- a/apps/rpg-maestro-ui/src/app/maestro-ui/voice-track-selection/microphone-track-button.tsx
+++ b/apps/rpg-maestro-ui/src/app/maestro-ui/voice-track-selection/microphone-track-button.tsx
@@ -4,7 +4,6 @@ import Tooltip from '@mui/material/Tooltip';
 import CircularProgress from '@mui/material/CircularProgress';
 import MicIcon from '@mui/icons-material/Mic';
 import { Tag } from '@rpg-maestro/rpg-maestro-api-contract';
-import { isDevModeEnabled } from '../../../FeaturesConfiguration';
 import { useVoiceTrackSelection, VoiceSelectionResult } from './use-voice-track-selection';
 
 export interface MicrophoneTrackButtonProps {
@@ -12,6 +11,8 @@ export interface MicrophoneTrackButtonProps {
   availableTags: Tag[];
   /** Called with the tags (and transcript) derived from the spoken audio. */
   onResult: (result: VoiceSelectionResult) => void;
+  /** The feature is admin-only; the button renders nothing unless this is true. */
+  isAdmin: boolean;
   /** Overrides how long the microphone listens. */
   listeningDurationMs?: number;
 }
@@ -24,25 +25,32 @@ const BUTTON_LABEL: Record<'idle' | 'listening' | 'interpreting', string> = {
 
 /**
  * Microphone button that listens to the maestro, transcribes what is said, and asks
- * the interpretation layer which tags to play. The feature is experimental, so the
- * button is only enabled in the dev environment (and only when a transcription
- * provider is available); elsewhere it is rendered disabled with an explanatory tooltip.
+ * the interpretation layer which tags to play. The feature is admin-only: for non-admin
+ * users the button is not rendered at all. When visible it is enabled as long as a
+ * transcription provider is available; otherwise it is disabled with an explanatory tooltip.
  */
-export function MicrophoneTrackButton({ availableTags, onResult, listeningDurationMs }: MicrophoneTrackButtonProps) {
+export function MicrophoneTrackButton({
+  availableTags,
+  onResult,
+  isAdmin,
+  listeningDurationMs,
+}: MicrophoneTrackButtonProps) {
   const { status, partialTranscript, isSupported, start } = useVoiceTrackSelection({
     availableTags,
     onResult,
     listeningDurationMs,
   });
 
-  const isBusy = status !== 'idle';
-  const enabled = isDevModeEnabled && isSupported && !isBusy;
+  if (!isAdmin) {
+    return null;
+  }
 
-  const disabledReason = !isDevModeEnabled
-    ? 'Voice track selection is only available in the development environment'
-    : !isSupported
-      ? 'Your browser does not support speech recognition (try Chrome or Edge)'
-      : '';
+  const isBusy = status !== 'idle';
+  const enabled = isSupported && !isBusy;
+
+  const disabledReason = !isSupported
+    ? 'Your browser does not support speech recognition (try Chrome or Edge)'
+    : '';
 
   const tooltipTitle =
     status === 'listening' && partialTranscript !== ''

--- a/apps/rpg-maestro-ui/src/app/maestro-ui/voice-track-selection/track-matching.spec.ts
+++ b/apps/rpg-maestro-ui/src/app/maestro-ui/voice-track-selection/track-matching.spec.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest';
+import { Track } from '@rpg-maestro/rpg-maestro-api-contract';
+import { collectAvailableTags, pickBestMatchingTrack } from './track-matching';
+
+function makeTrack(id: string, tags: string[]): Track {
+  return {
+    id,
+    sessionId: 'session-1',
+    created_at: 0,
+    updated_at: 0,
+    source: { origin_media: 'file', origin_url: '', origin_name: '' },
+    name: id,
+    duration: 1000,
+    tags,
+    url: `https://example.test/${id}.mp3`,
+  };
+}
+
+describe('pickBestMatchingTrack', () => {
+  it('prefers the track with the most overlapping tags', () => {
+    const tracks = [
+      makeTrack('one-tag', ['combat']),
+      makeTrack('two-tags', ['combat', 'dungeon']),
+    ];
+    const picked = pickBestMatchingTrack(tracks, ['combat', 'dungeon']);
+    expect(picked?.id).toBe('two-tags');
+  });
+
+  it('returns null when no track shares any requested tag', () => {
+    const tracks = [makeTrack('forest', ['forest'])];
+    expect(pickBestMatchingTrack(tracks, ['combat'])).toBeNull();
+  });
+
+  it('returns null when no tags are requested', () => {
+    const tracks = [makeTrack('forest', ['forest'])];
+    expect(pickBestMatchingTrack(tracks, [])).toBeNull();
+  });
+
+  it('excludes the currently playing track', () => {
+    const tracks = [makeTrack('current', ['combat']), makeTrack('other', ['combat'])];
+    const picked = pickBestMatchingTrack(tracks, ['combat'], { excludeTrackId: 'current' });
+    expect(picked?.id).toBe('other');
+  });
+
+  it('matches tags case-insensitively', () => {
+    const tracks = [makeTrack('t', ['Combat'])];
+    expect(pickBestMatchingTrack(tracks, ['combat'])?.id).toBe('t');
+  });
+
+  it('chooses among top-scored tracks using injected randomness', () => {
+    const tracks = [makeTrack('a', ['combat']), makeTrack('b', ['combat']), makeTrack('c', ['combat'])];
+    expect(pickBestMatchingTrack(tracks, ['combat'], { random: () => 0 })?.id).toBe('a');
+    expect(pickBestMatchingTrack(tracks, ['combat'], { random: () => 0.99 })?.id).toBe('c');
+  });
+});
+
+describe('collectAvailableTags', () => {
+  it('returns the sorted, de-duplicated set of tags across tracks', () => {
+    const tracks = [makeTrack('a', ['forest', 'combat']), makeTrack('b', ['combat', 'travel'])];
+    expect(collectAvailableTags(tracks)).toEqual(['combat', 'forest', 'travel']);
+  });
+
+  it('returns an empty array for no tracks', () => {
+    expect(collectAvailableTags([])).toEqual([]);
+  });
+});

--- a/apps/rpg-maestro-ui/src/app/maestro-ui/voice-track-selection/track-matching.ts
+++ b/apps/rpg-maestro-ui/src/app/maestro-ui/voice-track-selection/track-matching.ts
@@ -1,0 +1,62 @@
+import { Tag, Track } from '@rpg-maestro/rpg-maestro-api-contract';
+
+export interface PickBestMatchingTrackOptions {
+  /** Track to exclude from selection (typically the currently playing one). */
+  excludeTrackId?: string;
+  /** Injectable randomness for deterministic tests. Defaults to Math.random. */
+  random?: () => number;
+}
+
+/**
+ * Picks a single track that matches the requested tags "as best as possible":
+ * each candidate is scored by how many of its tags overlap the requested tags
+ * (case-insensitive), and one track is chosen at random among the highest scorers.
+ *
+ * Returns null when no track shares any tag with the request.
+ */
+export function pickBestMatchingTrack(
+  tracks: Track[],
+  tags: Tag[],
+  options: PickBestMatchingTrackOptions = {}
+): Track | null {
+  const { excludeTrackId, random = Math.random } = options;
+  const requested = new Set(tags.map((tag) => tag.toLowerCase()));
+  if (requested.size === 0) {
+    return null;
+  }
+
+  let bestScore = 0;
+  let bestTracks: Track[] = [];
+  for (const track of tracks) {
+    if (track.id === excludeTrackId) {
+      continue;
+    }
+    const score = track.tags.reduce((count, tag) => (requested.has(tag.toLowerCase()) ? count + 1 : count), 0);
+    if (score === 0) {
+      continue;
+    }
+    if (score > bestScore) {
+      bestScore = score;
+      bestTracks = [track];
+    } else if (score === bestScore) {
+      bestTracks.push(track);
+    }
+  }
+
+  if (bestTracks.length === 0) {
+    return null;
+  }
+  const index = Math.floor(random() * bestTracks.length);
+  return bestTracks[index];
+}
+
+/** Collects the unique set of tags used across the given tracks, sorted for stability. */
+export function collectAvailableTags(tracks: Track[]): Tag[] {
+  const tags = new Set<Tag>();
+  for (const track of tracks) {
+    for (const tag of track.tags) {
+      tags.add(tag);
+    }
+  }
+  return [...tags].sort((a, b) => a.localeCompare(b));
+}

--- a/apps/rpg-maestro-ui/src/app/maestro-ui/voice-track-selection/transcription/transcription-provider-registry.ts
+++ b/apps/rpg-maestro-ui/src/app/maestro-ui/voice-track-selection/transcription/transcription-provider-registry.ts
@@ -1,0 +1,17 @@
+import { TranscriptionProvider } from './transcription-provider';
+import { WebSpeechTranscriptionProvider } from './web-speech-transcription-provider';
+
+/**
+ * Ordered list of known transcription providers, most-preferred first.
+ * Add future providers (e.g. a local Whisper WASM model) here.
+ */
+export function getTranscriptionProviders(): TranscriptionProvider[] {
+  return [new WebSpeechTranscriptionProvider()];
+}
+
+/** Returns the first provider that is supported in the current environment, or null. */
+export function resolveTranscriptionProvider(
+  providers: TranscriptionProvider[] = getTranscriptionProviders()
+): TranscriptionProvider | null {
+  return providers.find((provider) => provider.isSupported()) ?? null;
+}

--- a/apps/rpg-maestro-ui/src/app/maestro-ui/voice-track-selection/transcription/transcription-provider.ts
+++ b/apps/rpg-maestro-ui/src/app/maestro-ui/voice-track-selection/transcription/transcription-provider.ts
@@ -1,0 +1,33 @@
+/**
+ * Provider-agnostic contract for turning a short burst of microphone audio into text.
+ *
+ * The first concrete implementation is the browser-native Web Speech API
+ * ({@link WebSpeechTranscriptionProvider}). The abstraction leaves room for future
+ * providers (e.g. a local Whisper WASM model, or a cloud transcription API) — each
+ * provider owns how it captures audio and produces a transcript.
+ */
+
+export interface TranscriptionResult {
+  /** The recognised text (may be empty if nothing was understood). */
+  transcript: string;
+  /** Name of the provider that produced this result. */
+  provider: string;
+}
+
+export interface TranscriptionListenOptions {
+  /** How long to listen to the microphone before resolving, in milliseconds. */
+  durationMs: number;
+  /** Called with the best-so-far transcript while listening, for live UI feedback. */
+  onPartialTranscript?: (partialTranscript: string) => void;
+  /** Allows the caller to cancel listening early (e.g. on unmount). */
+  signal?: AbortSignal;
+}
+
+export interface TranscriptionProvider {
+  /** Stable identifier used in logs and results. */
+  readonly name: string;
+  /** Whether this provider can run in the current environment. */
+  isSupported(): boolean;
+  /** Listen to the microphone for `durationMs`, then resolve with the transcript. */
+  listen(options: TranscriptionListenOptions): Promise<TranscriptionResult>;
+}

--- a/apps/rpg-maestro-ui/src/app/maestro-ui/voice-track-selection/transcription/web-speech-transcription-provider.ts
+++ b/apps/rpg-maestro-ui/src/app/maestro-ui/voice-track-selection/transcription/web-speech-transcription-provider.ts
@@ -1,0 +1,122 @@
+import {
+  TranscriptionListenOptions,
+  TranscriptionProvider,
+  TranscriptionResult,
+} from './transcription-provider';
+import { getSpeechRecognitionCtor, SpeechRecognitionLike } from './web-speech.types';
+
+/**
+ * Transcription provider backed by the browser-native Web Speech API
+ * (`SpeechRecognition` / `webkitSpeechRecognition`). Adds no dependencies and needs
+ * no model download, but is only available in Chromium-based browsers and relies on
+ * the browser's (potentially remote) recognition service.
+ */
+export class WebSpeechTranscriptionProvider implements TranscriptionProvider {
+  readonly name = 'web-speech';
+
+  isSupported(): boolean {
+    return getSpeechRecognitionCtor() !== undefined;
+  }
+
+  listen({ durationMs, onPartialTranscript, signal }: TranscriptionListenOptions): Promise<TranscriptionResult> {
+    const SpeechRecognitionCtor = getSpeechRecognitionCtor();
+    if (!SpeechRecognitionCtor) {
+      return Promise.reject(new Error('SpeechRecognition is not supported in this browser'));
+    }
+
+    return new Promise<TranscriptionResult>((resolve, reject) => {
+      const recognition: SpeechRecognitionLike = new SpeechRecognitionCtor();
+      recognition.continuous = true;
+      recognition.interimResults = true;
+      recognition.lang = navigator.language || 'en-US';
+
+      let finalTranscript = '';
+      let settled = false;
+      const timers: { stop?: ReturnType<typeof setTimeout> } = {};
+
+      const cleanup = (): void => {
+        if (timers.stop) {
+          clearTimeout(timers.stop);
+        }
+        signal?.removeEventListener('abort', onAbort);
+        recognition.onresult = null;
+        recognition.onerror = null;
+        recognition.onend = null;
+      };
+
+      const resolveOnce = (): void => {
+        if (settled) {
+          return;
+        }
+        settled = true;
+        cleanup();
+        resolve({ transcript: finalTranscript.trim(), provider: this.name });
+      };
+
+      const rejectOnce = (error: Error): void => {
+        if (settled) {
+          return;
+        }
+        settled = true;
+        cleanup();
+        reject(error);
+      };
+
+      const onAbort = (): void => {
+        try {
+          recognition.abort();
+        } catch {
+          // ignore — we are tearing down anyway
+        }
+        rejectOnce(new DOMException('Transcription aborted', 'AbortError'));
+      };
+
+      recognition.onresult = (event): void => {
+        let interim = '';
+        for (let i = event.resultIndex; i < event.results.length; i++) {
+          const result = event.results[i];
+          const text = result[0]?.transcript ?? '';
+          if (result.isFinal) {
+            finalTranscript += text;
+          } else {
+            interim += text;
+          }
+        }
+        onPartialTranscript?.(`${finalTranscript} ${interim}`.trim());
+      };
+
+      recognition.onerror = (event): void => {
+        // A silent recording ('no-speech') or a deliberate stop ('aborted') is not a
+        // hard failure — resolve with whatever text (if any) we already captured.
+        if (event.error === 'no-speech' || event.error === 'aborted') {
+          resolveOnce();
+          return;
+        }
+        rejectOnce(new Error(`Speech recognition error: ${event.error}`));
+      };
+
+      recognition.onend = (): void => resolveOnce();
+
+      if (signal?.aborted) {
+        onAbort();
+        return;
+      }
+      signal?.addEventListener('abort', onAbort);
+
+      try {
+        recognition.start();
+      } catch (error) {
+        rejectOnce(error instanceof Error ? error : new Error(String(error)));
+        return;
+      }
+
+      timers.stop = setTimeout(() => {
+        try {
+          recognition.stop();
+        } catch {
+          // `onend` will still fire and resolve the promise
+        }
+      }, durationMs);
+    });
+  }
+}

--- a/apps/rpg-maestro-ui/src/app/maestro-ui/voice-track-selection/transcription/web-speech.types.ts
+++ b/apps/rpg-maestro-ui/src/app/maestro-ui/voice-track-selection/transcription/web-speech.types.ts
@@ -1,0 +1,61 @@
+// Minimal ambient declarations for the Web Speech API (SpeechRecognition).
+// The DOM lib shipped with TypeScript does not include these yet, and only
+// Chromium-based browsers expose them (behind the `webkit` prefix as well).
+// We declare just the surface we use.
+
+export interface SpeechRecognitionAlternative {
+  readonly transcript: string;
+  readonly confidence: number;
+}
+
+export interface SpeechRecognitionResult {
+  readonly isFinal: boolean;
+  readonly length: number;
+  [index: number]: SpeechRecognitionAlternative;
+}
+
+export interface SpeechRecognitionResultList {
+  readonly length: number;
+  [index: number]: SpeechRecognitionResult;
+}
+
+export interface SpeechRecognitionEvent extends Event {
+  readonly resultIndex: number;
+  readonly results: SpeechRecognitionResultList;
+}
+
+export interface SpeechRecognitionErrorEvent extends Event {
+  readonly error: string;
+  readonly message: string;
+}
+
+export interface SpeechRecognitionLike {
+  lang: string;
+  continuous: boolean;
+  interimResults: boolean;
+  onresult: ((event: SpeechRecognitionEvent) => void) | null;
+  onerror: ((event: SpeechRecognitionErrorEvent) => void) | null;
+  onend: ((event: Event) => void) | null;
+  start(): void;
+  stop(): void;
+  abort(): void;
+}
+
+export interface SpeechRecognitionConstructor {
+  new (): SpeechRecognitionLike;
+}
+
+/**
+ * Returns the browser's SpeechRecognition constructor (standard or webkit-prefixed),
+ * or undefined when the API is unavailable (non-Chromium browsers, SSR).
+ */
+export function getSpeechRecognitionCtor(): SpeechRecognitionConstructor | undefined {
+  if (typeof window === 'undefined') {
+    return undefined;
+  }
+  const w = window as unknown as {
+    SpeechRecognition?: SpeechRecognitionConstructor;
+    webkitSpeechRecognition?: SpeechRecognitionConstructor;
+  };
+  return w.SpeechRecognition ?? w.webkitSpeechRecognition;
+}

--- a/apps/rpg-maestro-ui/src/app/maestro-ui/voice-track-selection/use-voice-track-selection.ts
+++ b/apps/rpg-maestro-ui/src/app/maestro-ui/voice-track-selection/use-voice-track-selection.ts
@@ -1,0 +1,129 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { Tag } from '@rpg-maestro/rpg-maestro-api-contract';
+import { toastError, toastInfo } from '../../ui-components/toast-popup';
+import { resolveTranscriptionProvider } from './transcription/transcription-provider-registry';
+import { resolveInterpretationProvider } from './interpretation/interpretation-provider-registry';
+
+export const DEFAULT_LISTENING_DURATION_MS = 15_000;
+
+export type VoiceSelectionStatus = 'idle' | 'listening' | 'interpreting';
+
+export interface VoiceSelectionResult {
+  tags: Tag[];
+  transcript: string;
+}
+
+export interface UseVoiceTrackSelectionParams {
+  /** Tags available in the session — the vocabulary the interpreter may output. */
+  availableTags: Tag[];
+  /** Called once tags have been derived from the spoken transcript. */
+  onResult: (result: VoiceSelectionResult) => void;
+  /** How long to listen to the microphone. Defaults to {@link DEFAULT_LISTENING_DURATION_MS}. */
+  listeningDurationMs?: number;
+}
+
+export interface UseVoiceTrackSelection {
+  status: VoiceSelectionStatus;
+  /** Best-so-far transcript while listening, for live UI feedback. */
+  partialTranscript: string;
+  /** Whether a supported transcription provider exists in this environment. */
+  isSupported: boolean;
+  /** Begin the listen → interpret → onResult flow. No-op if already running. */
+  start: () => void;
+}
+
+/**
+ * Orchestrates the voice-driven track selection flow: listen to the microphone,
+ * transcribe, interpret the transcript into session tags, and hand the tags back to
+ * the caller. Provider selection is delegated to the transcription/interpretation
+ * registries so the concrete implementations can evolve independently.
+ */
+export function useVoiceTrackSelection({
+  availableTags,
+  onResult,
+  listeningDurationMs = DEFAULT_LISTENING_DURATION_MS,
+}: UseVoiceTrackSelectionParams): UseVoiceTrackSelection {
+  const [status, setStatus] = useState<VoiceSelectionStatus>('idle');
+  const [partialTranscript, setPartialTranscript] = useState('');
+
+  const transcriptionProvider = useMemo(() => resolveTranscriptionProvider(), []);
+  const interpretationProvider = useMemo(() => resolveInterpretationProvider(), []);
+
+  // Keep the latest values without forcing `start` to be re-created every render.
+  const availableTagsRef = useRef(availableTags);
+  availableTagsRef.current = availableTags;
+  const onResultRef = useRef(onResult);
+  onResultRef.current = onResult;
+
+  const abortControllerRef = useRef<AbortController | null>(null);
+  const isMountedRef = useRef(true);
+  useEffect(() => {
+    return () => {
+      isMountedRef.current = false;
+      abortControllerRef.current?.abort();
+    };
+  }, []);
+
+  const isSupported = transcriptionProvider !== null;
+
+  const start = useCallback((): void => {
+    if (!transcriptionProvider) {
+      toastError('Voice track selection is not supported in this browser.', 5000);
+      return;
+    }
+    if (abortControllerRef.current) {
+      return; // a run is already in progress
+    }
+
+    const abortController = new AbortController();
+    abortControllerRef.current = abortController;
+    setPartialTranscript('');
+    setStatus('listening');
+
+    const run = async (): Promise<void> => {
+      const { transcript } = await transcriptionProvider.listen({
+        durationMs: listeningDurationMs,
+        signal: abortController.signal,
+        onPartialTranscript: (partial) => {
+          if (isMountedRef.current) {
+            setPartialTranscript(partial);
+          }
+        },
+      });
+
+      if (!isMountedRef.current) {
+        return;
+      }
+      setStatus('interpreting');
+
+      if (transcript.trim() === '') {
+        toastInfo('Did not catch anything — try speaking a bit louder.', 4000);
+        return;
+      }
+
+      const { tags } = await interpretationProvider.interpret({
+        transcript,
+        availableTags: availableTagsRef.current,
+      });
+      onResultRef.current({ tags, transcript });
+    };
+
+    run()
+      .catch((error: unknown) => {
+        if (error instanceof DOMException && error.name === 'AbortError') {
+          return; // cancelled (e.g. component unmounted) — nothing to report
+        }
+        console.error('Voice track selection failed', error);
+        toastError('Could not select a track from your voice. Please try again.', 5000);
+      })
+      .finally(() => {
+        abortControllerRef.current = null;
+        if (isMountedRef.current) {
+          setStatus('idle');
+          setPartialTranscript('');
+        }
+      });
+  }, [transcriptionProvider, interpretationProvider, listeningDurationMs]);
+
+  return { status, partialTranscript, isSupported, start };
+}


### PR DESCRIPTION
## What

Adds an experimental **microphone button** to the maestro soundboard. When clicked it:

1. Listens to the microphone for ~15s
2. Transcribes the audio to text
3. Builds an interpretation from **two inputs** — the transcript and the session's available track tags — producing a list of tags to play
4. Plays a random track that best matches those tags

## Architecture

Both moving parts are **pluggable multi-provider layers**, so the concrete implementations can evolve independently. New dir: `apps/rpg-maestro-ui/src/app/maestro-ui/voice-track-selection/`.

**Transcription** (`transcription/`)
- `TranscriptionProvider` interface (`isSupported()`, `listen({durationMs, onPartialTranscript, signal})`) + registry
- First impl: `WebSpeechTranscriptionProvider` — browser-native Web Speech API, **zero new dependencies** (Chrome/Edge). Minimal ambient types provided since the DOM lib lacks `SpeechRecognition`.

**Interpretation** (`interpretation/`)
- `TagInterpretationProvider` interface (`{transcript, availableTags}` → tags) + registry
- First impl: `PatternMatchingInterpretationProvider` — deterministic keyword→tag rules (e.g. sword/bow → `combat`), whole-word matched, intersected with the session's real tags. Stand-in for a real LLM.
- `buildTagInterpretationPrompt()` holds the actual LLM prompt a future real-LLM provider will send.

**Orchestration & UI**
- `useVoiceTrackSelection` hook — `idle → listening → interpreting → idle` state machine
- `pickBestMatchingTrack()` — scores tracks by tag overlap, random pick among top scorers
- `MicrophoneTrackButton` — sits next to the quick-tags; pulsing mic while listening, spinner while interpreting

## Dev-only gating

The button is enabled only when `isDevModeEnabled` **and** a transcription provider is supported; otherwise it renders **disabled** with an explanatory tooltip. In a production build it is always disabled.

## Tests

- `nx test rpg-maestro-ui` → **63 passed** (new: pattern matcher, best-match picker, button gating)
- `nx lint rpg-maestro-ui` → clean (only pre-existing warnings)
- `nx build rpg-maestro-ui` → success

The live mic capture (real audio + Chromium speech service) can't be driven headlessly; the deterministic logic around it is unit-tested.