### PR TITLE
perf(api): negatively cache missing sessions to cut Firestore reads

### DIFF
--- a/apps/rpg-maestro/src/app/sessions/sessions.cache.ts
+++ b/apps/rpg-maestro/src/app/sessions/sessions.cache.ts
@@ -2,21 +2,46 @@ import Keyv from 'keyv';
 import ms from 'ms';
 import { SessionPlayingTracks } from '@rpg-maestro/rpg-maestro-api-contract';
 
+export const SESSIONS_CACHE_TTL = ms('1 day');
+
+/**
+ * TTL for negative entries ("this session does not exist"), deliberately much shorter than the
+ * positive TTL. A negative entry is a promise that the key is absent, and that promise goes stale
+ * the instant someone creates the session. The cache is per-process today (see the TODO in
+ * SessionsService), so another instance creating a session cannot invalidate our negative entry:
+ * the TTL is the only bound on that staleness window. A few seconds is enough to absorb the
+ * 1-request-per-second player polling while keeping a wrongly cached 404 self-healing quickly.
+ */
+export const SESSIONS_NEGATIVE_CACHE_TTL = ms('10 seconds');
+
+/**
+ * Three distinct states, do not collapse them:
+ * - `undefined`: nothing is cached, the caller must ask the database
+ * - `null`: the database confirmed the session does not exist (negative entry)
+ * - a `SessionPlayingTracks`: cached value
+ */
+export type CachedSession = SessionPlayingTracks | null | undefined;
+
 export class SessionsCache {
-  private cache: Keyv<SessionPlayingTracks>;
+  private cache: Keyv<SessionPlayingTracks | null>;
 
   constructor() {
-    this.cache = new Keyv<SessionPlayingTracks>({
+    this.cache = new Keyv<SessionPlayingTracks | null>({
       namespace: 'rpg_maestro_sessions',
-      ttl: ms('1 day'),
+      ttl: SESSIONS_CACHE_TTL,
     });
   }
 
-  async get(sessionId: string): Promise<SessionPlayingTracks | undefined> {
+  async get(sessionId: string): Promise<CachedSession> {
     return await this.cache.get(sessionId);
   }
 
   async set(session: SessionPlayingTracks): Promise<void> {
-    await this.cache.set(session.sessionId, session);
+    await this.cache.set(session.sessionId, session, SESSIONS_CACHE_TTL);
+  }
+
+  /** Remembers that the database has no such session, so we stop querying it on every poll. */
+  async setAbsent(sessionId: string): Promise<void> {
+    await this.cache.set(sessionId, null, SESSIONS_NEGATIVE_CACHE_TTL);
   }
 }

--- a/apps/rpg-maestro/src/app/sessions/sessions.service.spec.ts
+++ b/apps/rpg-maestro/src/app/sessions/sessions.service.spec.ts
@@ -1,0 +1,133 @@
+import { PlayingTrack } from '@rpg-maestro/rpg-maestro-api-contract';
+import { DatabaseWrapperConfiguration } from '../DatabaseWrapperConfiguration';
+import { SessionsService } from './sessions.service';
+import { TracksDatabase } from '../maestro-api/TracksDatabase';
+import { SESSIONS_NEGATIVE_CACHE_TTL, SessionsCache } from './sessions.cache';
+
+const aPlayingTrack = (trackId: string): PlayingTrack => ({
+  id: trackId,
+  name: trackId,
+  url: `http://localhost/${trackId}.mp3`,
+  duration: 1000,
+  isPaused: false,
+  playTimestamp: 42,
+  trackStartTime: 0,
+});
+
+let databases: DatabaseWrapperConfiguration;
+let tracksDatabase: TracksDatabase;
+let sessionsService: SessionsService;
+
+beforeEach(() => {
+  databases = new DatabaseWrapperConfiguration('in-memory');
+  tracksDatabase = databases.getTracksDB();
+  sessionsService = new SessionsService(databases);
+});
+
+describe('SessionsService negative caching', () => {
+  it('should only hit the database once for an unknown session, even when polled repeatedly', async () => {
+    const getSessionSpy = vi.spyOn(tracksDatabase, 'getSession');
+
+    expect(await sessionsService.get('does-not-exist')).toBeNull();
+    expect(await sessionsService.get('does-not-exist')).toBeNull();
+    expect(await sessionsService.get('does-not-exist')).toBeNull();
+
+    expect(getSessionSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('should keep hitting the database only once for a session that exists', async () => {
+    await sessionsService.create('existing-session');
+    const getSessionSpy = vi.spyOn(tracksDatabase, 'getSession');
+
+    expect((await sessionsService.get('existing-session')).sessionId).toEqual('existing-session');
+    expect((await sessionsService.get('existing-session')).sessionId).toEqual('existing-session');
+
+    expect(getSessionSpy).not.toHaveBeenCalled();
+  });
+
+  it('should replace the negative entry when the session is created', async () => {
+    expect(await sessionsService.get('session-to-create')).toBeNull();
+
+    await sessionsService.create('session-to-create');
+
+    const session = await sessionsService.get('session-to-create');
+    expect(session).not.toBeNull();
+    expect(session.sessionId).toEqual('session-to-create');
+  });
+
+  it('should replace the negative entry when the current track is upserted', async () => {
+    expect(await sessionsService.get('session-to-play')).toBeNull();
+
+    await sessionsService.upsertCurrentTrack('session-to-play', aPlayingTrack('track-1'));
+
+    const session = await sessionsService.get('session-to-play');
+    expect(session).not.toBeNull();
+    expect(session.currentTrack.id).toEqual('track-1');
+  });
+
+  it('should replace the negative entry when a short effect track is upserted', async () => {
+    expect(await sessionsService.get('session-with-effect')).toBeNull();
+
+    await sessionsService.upsertShortEffectTrack('session-with-effect', aPlayingTrack('effect-1'));
+
+    const session = await sessionsService.get('session-with-effect');
+    expect(session).not.toBeNull();
+    expect(session.shortEffectTrack.id).toEqual('effect-1');
+  });
+
+  it('should ask the database again once the negative entry expired', async () => {
+    vi.useFakeTimers();
+    try {
+      const getSessionSpy = vi.spyOn(tracksDatabase, 'getSession');
+
+      expect(await sessionsService.get('later-created-session')).toBeNull();
+      expect(getSessionSpy).toHaveBeenCalledTimes(1);
+
+      // the session gets created by another instance, which cannot invalidate our negative entry
+      await tracksDatabase.createSession('later-created-session');
+      expect(await sessionsService.get('later-created-session')).toBeNull();
+      expect(getSessionSpy).toHaveBeenCalledTimes(1);
+
+      vi.setSystemTime(Date.now() + SESSIONS_NEGATIVE_CACHE_TTL + 1);
+
+      const session = await sessionsService.get('later-created-session');
+      expect(session).not.toBeNull();
+      expect(session.sessionId).toEqual('later-created-session');
+      expect(getSessionSpy).toHaveBeenCalledTimes(2);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});
+
+describe('SessionsCache', () => {
+  it('should use a short ttl for negative entries and the long one for positive entries', async () => {
+    vi.useFakeTimers();
+    try {
+      const cache = new SessionsCache();
+      await cache.setAbsent('absent-session');
+      await cache.set({ sessionId: 'present-session', currentTrack: null, shortEffectTrack: null });
+
+      expect(await cache.get('absent-session')).toBeNull();
+      expect(await cache.get('present-session')).not.toBeUndefined();
+
+      vi.setSystemTime(Date.now() + SESSIONS_NEGATIVE_CACHE_TTL + 1);
+
+      // the negative entry is gone, so the next lookup asks the database again
+      expect(await cache.get('absent-session')).toBeUndefined();
+      // while the positive entry, with its 1 day ttl, is still cached
+      expect(await cache.get('present-session')).not.toBeUndefined();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('should distinguish "nothing cached" (undefined) from "known absent" (null)', async () => {
+    const cache = new SessionsCache();
+
+    expect(await cache.get('never-seen-session')).toBeUndefined();
+
+    await cache.setAbsent('never-seen-session');
+    expect(await cache.get('never-seen-session')).toBeNull();
+  });
+});

--- a/apps/rpg-maestro/src/app/sessions/sessions.service.ts
+++ b/apps/rpg-maestro/src/app/sessions/sessions.service.ts
@@ -21,13 +21,20 @@ export class SessionsService {
     // TODO fix this hack forbidding having more than one instance
     // this was done to avoid reaching Firestore quotas
     const cachedSession = await this.cache.get(sessionId);
-    if (cachedSession) {
+    if (cachedSession === null) {
+      // negative entry: the database already told us this session does not exist, don't ask again
+      return null;
+    }
+    if (cachedSession !== undefined) {
       return cachedSession;
     }
     const sessionFromDB = await this.tracksDatabase.getSession(sessionId);
-    if (sessionFromDB != null) {
-      await this.cache.set(sessionFromDB);
+    if (sessionFromDB == null) {
+      // players poll every second, so an unknown sessionId would otherwise cost one DB read per second
+      await this.cache.setAbsent(sessionId);
+      return null;
     }
+    await this.cache.set(sessionFromDB);
     return sessionFromDB;
   }
 


### PR DESCRIPTION
## Problem

`SessionsCache` only stored values that were found. A `null` from the database was never cached, so every lookup for a non-existent session went to Firestore again.

The player UI polls `GET /sessions/:id/playing-tracks` every 1000ms per player (`apps/rpg-maestro-ui/src/app/players-ui.tsx:16`). A single browser tab pointed at a session id that does not exist (typo, expired link, stale bookmark) therefore generated **one Firestore read per second, forever**, with no upper bound on how many such tabs are open.

## Fix

`SessionsService.get()` now caches the "absent" answer too.

**Three states, kept explicit** — `Keyv.get()` returns `undefined` on a miss, so `null` is used as the stored sentinel for "known absent":

| cached value | meaning | behaviour |
| --- | --- | --- |
| `undefined` | nothing cached | ask the database |
| `null` | database confirmed absent (negative entry) | return `null` without asking |
| `SessionPlayingTracks` | cached value | return it |

This is expressed as an exported `CachedSession` type and handled as two separate branches at the call site — the two "falsy" cases are deliberately not collapsed.

**Negative entries use a separate, short TTL** — `SESSIONS_NEGATIVE_CACHE_TTL = ms('10 seconds')`, not the 1 day positive TTL. A negative entry is a promise that the key does not exist, and that promise goes stale the instant someone creates the session. The cache is per-process today (see the pre-existing `// TODO fix this hack forbidding having more than one instance`), so a second instance creating a session cannot invalidate the first instance's negative entry. A short TTL bounds that staleness window; the 1 day TTL would serve 404s for a day. 10s already collapses ~10 polls into 1 read (a >90% reduction on the pathological path) while a wrongly cached 404 self-heals almost immediately.

**Positive writes overwrite negative entries** — all session writes go through `SessionsService` (`create`, `upsertCurrentTrack`, `upsertShortEffectTrack`; verified no caller reaches `TracksDatabase` session writes directly), and each ends in `cache.set(...)` on the same key with the positive TTL. Verified by tests rather than by inspection alone.

## Tests

New `apps/rpg-maestro/src/app/sessions/sessions.service.spec.ts`:
- an unknown session polled 3x hits `TracksDatabase.getSession` exactly **once** (spy call count — the core assertion)
- an existing session is served from cache without any DB read
- `create` / `upsertCurrentTrack` / `upsertShortEffectTrack` each replace an existing negative entry
- after `SESSIONS_NEGATIVE_CACHE_TTL` elapses the database is queried again (simulating another instance having created the session)
- negative entries expire on the short TTL while positive entries survive it

`npx nx test rpg-maestro` → 11 files / 43 tests passed. `npx nx lint rpg-maestro` → 0 errors (7 pre-existing warnings, none in the touched files).

## Deliberately scoped out: users negative caching

`UsersCache` / `UsersService` are **unchanged**. `RolesGuard` calls `UsersService.get()` on every guarded request, so negative caching would help there, but it cannot be shipped safely as-is:

`UsersService` is declared as a provider in **two** modules — `UsersManagementModule` and `MaestroApiModule` — so there are two instances, each with its own private `UsersCache` that never sees the other's writes:

- `MaestroApiModule`'s instance backs `OnboardingService`, `AuthenticatedMaestroController`, and the `RolesGuard` used by controllers declared in `AppModule`.
- `UsersManagementModule`'s instance backs `GET /users/me` and the `RolesGuard` used by `AdminController` (`AdminModule` imports only `UsersManagementModule`). `TrackCollectionModule` imports *both* modules, so which instance its `RolesGuard` resolves is a Nest import-order detail rather than something guaranteed.

Concrete regression that would follow: a not-yet-onboarded user hits a guarded endpoint served by the `UsersManagementModule` instance (e.g. the track-collections page) → `RolesGuard` caches a negative entry → the user onboards, which writes through the *`MaestroApiModule`* instance → the first instance still holds its negative entry and keeps returning `403 NOT_YET_ONBOARDED` until the TTL expires. A 403 right after onboarding is a much worse bug than the reads it would save, and the safe path is not provable without changing the DI wiring.

Follow-up work, intentionally left out of this PR:
1. Fix the duplicate `UsersService` provider so there is exactly one instance (have `MaestroApiModule` import `UsersManagementModule` instead of re-declaring the provider), then add users negative caching on top.
2. Related pre-existing bug in `apps/rpg-maestro/src/app/auth/auth-guards.module.ts`: `RolesGuard` is registered under the `provide: JwtAuthGuard` token, shadowing the `JwtAuthGuard` provider declared just above it.
3. The shared-cache story (Redis/Valkey) that would remove the per-process constraint entirely is separate in-flight work and untouched here.