### PR TITLE
fix(ui): stop polling and explain when a session does not exist

### DIFF
--- a/apps/rpg-maestro-ui-e2e/src/players-ui.spec.ts
+++ b/apps/rpg-maestro-ui-e2e/src/players-ui.spec.ts
@@ -85,6 +85,46 @@ test('the Players UI shows a Discord help link in error toasts when the API fail
   });
 });
 
+test('the Players UI stops polling and explains itself when the session does not exist', async ({ page }) => {
+  const playingTracksUrl = '**/sessions/*/playing-tracks';
+  let requestCount = 0;
+
+  await test.step('make the session API report the session as missing, before the page loads', async () => {
+    await page.route(playingTracksUrl, (route) => {
+      requestCount++;
+      return route.fulfill({ status: 404, body: JSON.stringify({ message: 'Session not found' }) });
+    });
+  });
+
+  await test.step('navigate to a player page for a session that does not exist', async () => {
+    await page.goto('/session-that-does-not-exist');
+    await expect(page.locator('h1')).toContainText('RPG-Maestro player UI');
+  });
+
+  await test.step('the page explains that the session does not exist', async () => {
+    await expect(page.getByRole('alert')).toContainText(
+      "Session 'session-that-does-not-exist' does not exist. Double-check the link your Maestro shared with you."
+    );
+  });
+
+  await test.step('a missing session is not reported as a fetch failure', async () => {
+    await expect(page.getByRole('alert')).not.toContainText(/fetch current\/tracks error/i);
+  });
+
+  await test.step('the 1s sync loop is stopped, so no further request is made', async () => {
+    // Asserting the *absence* of a request needs a bounded wait: waitForRequest rejects on timeout,
+    // which is the assertion. 3s spans three would-be sync ticks (SYNC_TRACK_INTERVAL_MS = 1000).
+    const countAfterFirstFailure = requestCount;
+    const polledAgain = await page
+      .waitForRequest(playingTracksUrl, { timeout: 3000 })
+      .then(() => true)
+      .catch(() => false);
+
+    expect(polledAgain).toBe(false);
+    expect(requestCount).toBe(countAfterFirstFailure);
+  });
+});
+
 test('the Players UI updates the displayed track name when the Maestro changes the track', async ({ page }) => {
   let user: UserWithGeneratedSession;
   let firstTrackName: string;

--- a/apps/rpg-maestro-ui/src/app/maestro-ui/maestro-api.ts
+++ b/apps/rpg-maestro-ui/src/app/maestro-ui/maestro-api.ts
@@ -139,6 +139,12 @@ export const deleteTrackCollection = async (id: string): Promise<void> => {
 };
 
 export type AbortedRequestError = 'AbortedRequestError';
+
+/**
+ * The session does not exist. Unlike a fetch failure this is terminal: polling for it again will
+ * never succeed, so callers must stop their sync loop instead of retrying.
+ */
+export type SessionNotFoundError = 'SessionNotFoundError';
 interface OngoingSetTrackToPlayRequest {
   abortController: AbortController;
   startTimeMs: number;

--- a/apps/rpg-maestro-ui/src/app/maestro-ui/maestro-audio-player/maestro-audio-player.tsx
+++ b/apps/rpg-maestro-ui/src/app/maestro-ui/maestro-audio-player/maestro-audio-player.tsx
@@ -23,6 +23,7 @@ export const MaestroAudioPlayer = forwardRef((props: MaestroAudioPlayerProps, re
   const { sessionId, onCurrentTrackEdit } = props;
   const [currentTrack, setCurrentTrack] = useState<PlayingTrack | null>(null);
   const [currentTrackEditRequested, setCurrentTrackEditRequested] = useState<Promise<void> | null>(null);
+  const [sessionNotFound, setSessionNotFound] = useState(false);
   const isInUIResync = useRef(false);
   const audioPlayer = useRef<H5AudioPlayer>();
 
@@ -111,6 +112,9 @@ export const MaestroAudioPlayer = forwardRef((props: MaestroAudioPlayerProps, re
   };
 
   const periodicallySyncCurrentTrack = useCallback(async () => {
+    if (sessionNotFound) {
+      return Promise.resolve();
+    }
     if (currentTrackEditRequested !== null) {
       // prevent periodical sync when user has made actions
       return Promise.resolve();
@@ -122,6 +126,12 @@ export const MaestroAudioPlayer = forwardRef((props: MaestroAudioPlayerProps, re
         currentTrack,
         null,
       ).then((syncResult) => {
+        if (syncResult === 'SessionNotFoundError') {
+          // Terminal: retrying cannot help, so stop the sync loop instead of polling forever.
+          setSessionNotFound(true);
+          displayError(`Session '${sessionId}' does not exist.`);
+          return Promise.resolve();
+        }
         if (syncResult !== 'AbortedRequestError') {
           return resyncCurrentTrackOnUi(syncResult.currentTrack);
         }
@@ -129,15 +139,23 @@ export const MaestroAudioPlayer = forwardRef((props: MaestroAudioPlayerProps, re
       });
     const request = requestFunc();
     await request;
-  }, [currentTrackEditRequested, sessionId, currentTrack, resyncCurrentTrackOnUi]);
+  }, [currentTrackEditRequested, sessionId, currentTrack, resyncCurrentTrackOnUi, sessionNotFound]);
+
+  // A new session id deserves a fresh attempt, even if the previous one did not exist.
+  useEffect(() => {
+    setSessionNotFound(false);
+  }, [sessionId]);
 
   useEffect(() => {
+    if (sessionNotFound) {
+      return;
+    }
     periodicallySyncCurrentTrack();
     const id = setInterval(() => {
       periodicallySyncCurrentTrack();
     }, SYNC_TRACK_INTERVAL_MS);
     return () => clearInterval(id);
-  }, [periodicallySyncCurrentTrack, sessionId, currentTrack]);
+  }, [periodicallySyncCurrentTrack, sessionId, currentTrack, sessionNotFound]);
 
   useImperativeHandle(ref, () => ({
     dispatchTrackWasManuallyChanged,

--- a/apps/rpg-maestro-ui/src/app/players-ui/players-ui.tsx
+++ b/apps/rpg-maestro-ui/src/app/players-ui/players-ui.tsx
@@ -18,6 +18,7 @@ export const SYNC_TRACK_INTERVAL_MS = 1000;
 export function PlayersUi() {
   const [currentTrack, setCurrentTrack] = useState<PlayingTrack | null>(null);
   const [shortEffectTrack, setShortEffectTrack] = useState<PlayingTrack | null>(null);
+  const [sessionNotFound, setSessionNotFound] = useState(false);
   const audioPlayer = useRef<H5AudioPlayer>();
   const effectAudioRef = useRef<HTMLAudioElement>(null);
   const sessionId = useParams().sessionId ?? '';
@@ -25,7 +26,17 @@ export function PlayersUi() {
     displayError('no session found in URL (it should be https://{URL}/session/{sessionId})');
   }
 
+  // A new session id deserves a fresh attempt, even if the previous one did not exist.
   useEffect(() => {
+    setSessionNotFound(false);
+  }, [sessionId]);
+
+  useEffect(() => {
+    // Polling a session that does not exist can never succeed, so no interval is set up at all.
+    if (sessionNotFound) {
+      return;
+    }
+
     async function resyncOnUi() {
       const syncResult = await resyncIfNeeded(
         sessionId,
@@ -34,6 +45,11 @@ export function PlayersUi() {
         shortEffectTrack,
       );
       if (syncResult === 'AbortedRequestError') {
+        return;
+      }
+      if (syncResult === 'SessionNotFoundError') {
+        // Flipping this re-runs the effect, whose cleanup clears the interval below.
+        setSessionNotFound(true);
         return;
       }
 
@@ -90,7 +106,7 @@ export function PlayersUi() {
       resyncOnUi();
     }, SYNC_TRACK_INTERVAL_MS);
     return () => clearInterval(id);
-  }, [currentTrack, shortEffectTrack, sessionId]);
+  }, [currentTrack, shortEffectTrack, sessionId, sessionNotFound]);
 
   return (
     <div style={{ display: 'flex', flexDirection: 'column', justifyContent: 'space-around', alignItems: 'center', minHeight: '100vh', padding: '2rem' }}>
@@ -120,13 +136,24 @@ export function PlayersUi() {
         </div>
       </div>
 
-      <div style={{ textAlign: 'center', maxWidth: 800, margin: '2rem auto', color: 'var(--text-secondary)', lineHeight: 1.6 }}>
-        <p style={{ margin: '1rem 0', fontSize: '1.1rem' }}>
-          Welcome! This app is primarily meant for TTRPG games: a Maestro manages the current track being played, the
-          track is synced between all Players on this page.
-        </p>
-        <p style={{ margin: '1rem 0', fontSize: '1.1rem' }}>To avoid sync issues, Players can only change their volume.</p>
-      </div>
+      {sessionNotFound ? (
+        <div
+          role="alert"
+          style={{ textAlign: 'center', maxWidth: 800, margin: '2rem auto', color: 'var(--text-secondary)', lineHeight: 1.6 }}
+        >
+          <p style={{ margin: '1rem 0', fontSize: '1.1rem' }}>
+            Session &apos;{sessionId}&apos; does not exist. Double-check the link your Maestro shared with you.
+          </p>
+        </div>
+      ) : (
+        <div style={{ textAlign: 'center', maxWidth: 800, margin: '2rem auto', color: 'var(--text-secondary)', lineHeight: 1.6 }}>
+          <p style={{ margin: '1rem 0', fontSize: '1.1rem' }}>
+            Welcome! This app is primarily meant for TTRPG games: a Maestro manages the current track being played, the
+            track is synced between all Players on this page.
+          </p>
+          <p style={{ margin: '1rem 0', fontSize: '1.1rem' }}>To avoid sync issues, Players can only change their volume.</p>
+        </div>
+      )}
 
       <AudioPlayer
         ref={audioPlayer as LegacyRef<H5AudioPlayer>}

--- a/apps/rpg-maestro-ui/src/app/track-sync/track-sync.ts
+++ b/apps/rpg-maestro-ui/src/app/track-sync/track-sync.ts
@@ -1,6 +1,6 @@
 import { getSessionPlayingTracks } from '../tracks-api';
 import { PlayingTrack, SessionPlayingTracks } from '@rpg-maestro/rpg-maestro-api-contract';
-import { AbortedRequestError } from '../maestro-ui/maestro-api';
+import { AbortedRequestError, SessionNotFoundError } from '../maestro-ui/maestro-api';
 
 export interface SyncResult {
   currentTrack: PlayingTrack | null;
@@ -19,9 +19,9 @@ export const resyncIfNeeded = async (
   currentTrackPlayTime: number | null,
   currentTrack: PlayingTrack | null,
   localShortEffectTrack: PlayingTrack | null,
-): Promise<SyncResult | AbortedRequestError> => {
+): Promise<SyncResult | AbortedRequestError | SessionNotFoundError> => {
   const serverState = await getSessionPlayingTracks(sessionId);
-  if (serverState === 'AbortedRequestError') {
+  if (serverState === 'AbortedRequestError' || serverState === 'SessionNotFoundError') {
     return serverState;
   }
 

--- a/apps/rpg-maestro-ui/src/app/tracks-api.ts
+++ b/apps/rpg-maestro-ui/src/app/tracks-api.ts
@@ -1,6 +1,6 @@
 import { displayError } from './error-utils';
 import { PlayingTrack, SessionPlayingTracks } from '@rpg-maestro/rpg-maestro-api-contract';
-import { AbortedRequestError } from './maestro-ui/maestro-api';
+import { AbortedRequestError, SessionNotFoundError } from './maestro-ui/maestro-api';
 
 const rpgmaestroapiurl = import.meta.env.VITE_RPG_MAESTRO_API_URL;
 console.info('using api: ' + rpgmaestroapiurl);
@@ -26,7 +26,7 @@ let ongoingRequest: OngoingRequest | null = null;
 export const getSessionPlayingTracks = async (
   sessionId: string,
   options?: { manuallyRequested?: boolean }
-): Promise<SessionPlayingTracks | AbortedRequestError> => {
+): Promise<SessionPlayingTracks | AbortedRequestError | SessionNotFoundError> => {
   // Abort previous request if any
   if (ongoingRequest) {
     if (options?.manuallyRequested) {
@@ -54,6 +54,12 @@ export const getSessionPlayingTracks = async (
         currentTrack: res.currentTrack ? deserializePlayingTrack(res.currentTrack) : null,
         shortEffectTrack: res.shortEffectTrack ? deserializePlayingTrack(res.shortEffectTrack) : null,
       };
+    } else if (response.status === 404) {
+      // Expected outcome for a mistyped or stale session link, not a transport failure: report it as
+      // a distinct result so the caller can stop polling, and skip the error toast that would
+      // otherwise fire on every sync tick.
+      ongoingRequest = null;
+      return 'SessionNotFoundError';
     } else {
       console.error(response.status, response.statusText);
       console.error(response);


### PR DESCRIPTION
Replaces #107, which tried to absorb this server-side with negative caching.

## The bug

A browser pointed at a session id that does not exist polls `/sessions/:id/playing-tracks` forever:

- `players-ui.tsx` only cleared its 1s interval on unmount, never on error
- a 404 fell into the generic `catch` in `tracks-api.ts`, which toasted `Fetch current/tracks error: …` and returned an empty `SessionPlayingTracks`, so the loop kept going as if nothing had happened
- the user saw an empty audio player and repeated error toasts, with no indication that the link was simply wrong

The wasted requests were the visible symptom, but the UX was the real problem: a mistyped or stale link gives no usable feedback.

## The fix

Treat "session does not exist" as a distinct, terminal outcome rather than a transport failure:

- **`SessionNotFoundError`**, a new sentinel alongside the existing `AbortedRequestError`, following the same string-union idiom
- **`tracks-api.ts`** returns it for `response.status === 404` and skips the error toast — a mistyped link is an expected outcome, not a fetch failure. Also clears `ongoingRequest` on this path
- **`track-sync.ts`** propagates it through `resyncIfNeeded`
- **players UI** renders `Session '<id>' does not exist. Double-check the link your Maestro shared with you.` in a `role="alert"` container, and sets up no interval at all in that state
- **maestro player** stops its 5s sync loop and reports the problem once
- both reset the flag when `sessionId` changes, so a different id gets a fresh attempt

## Why not negative caching (#107)

Nothing in normal operation produces a cache miss on a missing session. `generateSessionId()` probes a fresh random id and `create()` immediately writes a positive entry over it, and real sessions never become 404s — there is no delete operation in `TracksDatabase`. So the steady state was already all positive-cache hits, and #107 improved nothing there. It only bounded the cost of a client bug that is better fixed in the client.

## Verification

- `nx lint rpg-maestro-ui`: 0 errors (3 pre-existing warnings, none in touched files)
- `tsc -p tsconfig.app.json --noEmit`: no new errors (identical count before/after; the 7 existing ones are in `admin-board.stories.tsx`, `theme.ts`, `FeaturesConfiguration.ts`)
- new e2e test in `players-ui.spec.ts`, passing in isolation in 3.4s. It asserts the message *and* that no further request is made — verified it actually catches the regression by removing the guard, which fails it on the polling assertion
- asserting the absence of a request needs a bounded wait, so it uses `page.waitForRequest({ timeout: 3000 })` and treats rejection as the pass condition. That is the documented-reason exception to the no-per-assertion-timeouts convention; 3s spans three would-be sync ticks

### Note on the local full-suite run

4 tests fail locally on `main` too, unrelated to this change — `POST /maestro/sessions` returns `401 Unauthorized`, which looks like fake-IDP/auth env setup. Verified identical on a clean tree. Because `players-ui.spec.ts` is `mode: 'serial'`, that pre-existing failure short-circuits the rest of the file, so the new test shows as "did not run" in a local full-suite run. It passes when run on its own, and should run in CI if the auth fixtures work there.