### PR TITLE
fix(ui): address review findings on missing-session handling

### DIFF
--- a/apps/rpg-maestro-ui-e2e/src/players-ui.spec.ts
+++ b/apps/rpg-maestro-ui-e2e/src/players-ui.spec.ts
@@ -115,19 +115,24 @@ test('the Players UI stops polling and explains itself when the session does not
     await expect(page.getByRole('alert')).toHaveCount(0);
   });
 
-  await test.step('the sync loop is stopped, so no further request is made', async () => {
+  await test.step('the sync loop is stopped, so it settles and then goes quiet', async () => {
+    // One tick can already be scheduled when the loop decides to stop, so drain that straggler
+    // rather than asserting an exact request count, which would be timing-dependent.
+    await page.waitForRequest(playingTracksUrl, { timeout: 1500 }).catch(() => undefined);
+
     // Asserting the *absence* of a request needs a bounded wait: waitForRequest rejects on timeout,
     // which is the assertion. 3s spans three would-be sync ticks (SYNC_TRACK_INTERVAL_MS = 1000).
-    const countWhenGivingUp = requestCount;
+    const countOnceSettled = requestCount;
     const polledAgain = await page
       .waitForRequest(playingTracksUrl, { timeout: 3000 })
       .then(() => true)
       .catch(() => false);
 
     expect(polledAgain).toBe(false);
-    // it takes CONSECUTIVE_NOT_FOUND_BEFORE_GIVING_UP strikes to give up, and not one more after
-    expect(requestCount).toBe(countWhenGivingUp);
-    expect(countWhenGivingUp).toBe(3);
+    expect(requestCount).toBe(countOnceSettled);
+    // gives up promptly: the threshold of strikes, plus at most one already-scheduled straggler
+    expect(countOnceSettled).toBeLessThanOrEqual(4);
+    expect(countOnceSettled).toBeGreaterThanOrEqual(3);
   });
 });
 

--- a/apps/rpg-maestro-ui-e2e/src/players-ui.spec.ts
+++ b/apps/rpg-maestro-ui-e2e/src/players-ui.spec.ts
@@ -102,26 +102,64 @@ test('the Players UI stops polling and explains itself when the session does not
   });
 
   await test.step('the page explains that the session does not exist', async () => {
-    await expect(page.getByRole('alert')).toContainText(
-      "Session 'session-that-does-not-exist' does not exist. Double-check the link your Maestro shared with you."
-    );
+    await expect(
+      page.getByText(
+        "Session 'session-that-does-not-exist' does not exist. Double-check the link your Maestro shared with you."
+      )
+    ).toBeVisible();
   });
 
   await test.step('a missing session is not reported as a fetch failure', async () => {
-    await expect(page.getByRole('alert')).not.toContainText(/fetch current\/tracks error/i);
+    // role="alert" is react-toastify's; the panel above deliberately uses role="status" so that this
+    // asserts no toast fired at all, rather than trivially matching the panel's own text.
+    await expect(page.getByRole('alert')).toHaveCount(0);
   });
 
-  await test.step('the 1s sync loop is stopped, so no further request is made', async () => {
+  await test.step('the sync loop is stopped, so no further request is made', async () => {
     // Asserting the *absence* of a request needs a bounded wait: waitForRequest rejects on timeout,
     // which is the assertion. 3s spans three would-be sync ticks (SYNC_TRACK_INTERVAL_MS = 1000).
-    const countAfterFirstFailure = requestCount;
+    const countWhenGivingUp = requestCount;
     const polledAgain = await page
       .waitForRequest(playingTracksUrl, { timeout: 3000 })
       .then(() => true)
       .catch(() => false);
 
     expect(polledAgain).toBe(false);
-    expect(requestCount).toBe(countAfterFirstFailure);
+    // it takes CONSECUTIVE_NOT_FOUND_BEFORE_GIVING_UP strikes to give up, and not one more after
+    expect(requestCount).toBe(countWhenGivingUp);
+    expect(countWhenGivingUp).toBe(3);
+  });
+});
+
+test('the Players UI recovers from a transient 404 instead of declaring the session gone', async ({ page }) => {
+  let user: UserWithGeneratedSession;
+  let trackName: string;
+
+  await test.step('prepare data: a real session with a track playing', async () => {
+    user = await generateNewSession(userFixture.a_maestro_B_user);
+    const track = await createTrackViaApi(user, user.sessionId, {
+      url: `${RPG_MAESTRO_URL}/public/race1.ogg`,
+      name: 'transient-404-recovery-test',
+    });
+    trackName = track.name;
+    await setTrackToPlayViaApi(user, user.sessionId, track.id);
+  });
+
+  await test.step('serve a single 404 — as an ingress would mid-deploy — then let requests through', async () => {
+    let served404 = false;
+    await page.route('**/sessions/*/playing-tracks', async (route) => {
+      if (!served404) {
+        served404 = true;
+        return route.fulfill({ status: 404, body: JSON.stringify({ message: 'Session not found' }) });
+      }
+      return route.fallback();
+    });
+  });
+
+  await test.step('one 404 is below the give-up threshold, so the player still syncs', async () => {
+    await page.goto(`/${user.sessionId}`);
+    await expect(page.getByText(trackName)).toBeVisible();
+    await expect(page.getByText(/does not exist/)).toHaveCount(0);
   });
 });
 

--- a/apps/rpg-maestro-ui/src/app/maestro-ui/maestro-audio-player/maestro-audio-player.tsx
+++ b/apps/rpg-maestro-ui/src/app/maestro-ui/maestro-audio-player/maestro-audio-player.tsx
@@ -23,7 +23,7 @@ export const MaestroAudioPlayer = forwardRef((props: MaestroAudioPlayerProps, re
   const { sessionId, onCurrentTrackEdit } = props;
   const [currentTrack, setCurrentTrack] = useState<PlayingTrack | null>(null);
   const [currentTrackEditRequested, setCurrentTrackEditRequested] = useState<Promise<void> | null>(null);
-  const [sessionNotFound, setSessionNotFound] = useState(false);
+  const missingSessionAlreadyReported = useRef(false);
   const isInUIResync = useRef(false);
   const audioPlayer = useRef<H5AudioPlayer>();
 
@@ -112,9 +112,6 @@ export const MaestroAudioPlayer = forwardRef((props: MaestroAudioPlayerProps, re
   };
 
   const periodicallySyncCurrentTrack = useCallback(async () => {
-    if (sessionNotFound) {
-      return Promise.resolve();
-    }
     if (currentTrackEditRequested !== null) {
       // prevent periodical sync when user has made actions
       return Promise.resolve();
@@ -127,11 +124,15 @@ export const MaestroAudioPlayer = forwardRef((props: MaestroAudioPlayerProps, re
         null,
       ).then((syncResult) => {
         if (syncResult === 'SessionNotFoundError') {
-          // Terminal: retrying cannot help, so stop the sync loop instead of polling forever.
-          setSessionNotFound(true);
-          displayError(`Session '${sessionId}' does not exist.`);
+          // Not terminal for a Maestro: upsertCurrentTrack creates the session, so playing a track
+          // brings it into existence. Keep syncing, but only report it once instead of every tick.
+          if (!missingSessionAlreadyReported.current) {
+            missingSessionAlreadyReported.current = true;
+            displayError(`Session '${sessionId}' does not exist yet, it will be created when you play a track.`);
+          }
           return Promise.resolve();
         }
+        missingSessionAlreadyReported.current = false;
         if (syncResult !== 'AbortedRequestError') {
           return resyncCurrentTrackOnUi(syncResult.currentTrack);
         }
@@ -139,23 +140,15 @@ export const MaestroAudioPlayer = forwardRef((props: MaestroAudioPlayerProps, re
       });
     const request = requestFunc();
     await request;
-  }, [currentTrackEditRequested, sessionId, currentTrack, resyncCurrentTrackOnUi, sessionNotFound]);
-
-  // A new session id deserves a fresh attempt, even if the previous one did not exist.
-  useEffect(() => {
-    setSessionNotFound(false);
-  }, [sessionId]);
+  }, [currentTrackEditRequested, sessionId, currentTrack, resyncCurrentTrackOnUi]);
 
   useEffect(() => {
-    if (sessionNotFound) {
-      return;
-    }
     periodicallySyncCurrentTrack();
     const id = setInterval(() => {
       periodicallySyncCurrentTrack();
     }, SYNC_TRACK_INTERVAL_MS);
     return () => clearInterval(id);
-  }, [periodicallySyncCurrentTrack, sessionId, currentTrack, sessionNotFound]);
+  }, [periodicallySyncCurrentTrack, sessionId, currentTrack]);
 
   useImperativeHandle(ref, () => ({
     dispatchTrackWasManuallyChanged,

--- a/apps/rpg-maestro-ui/src/app/players-ui/players-ui.tsx
+++ b/apps/rpg-maestro-ui/src/app/players-ui/players-ui.tsx
@@ -31,12 +31,14 @@ export function PlayersUi() {
   const audioPlayer = useRef<H5AudioPlayer>();
   const effectAudioRef = useRef<HTMLAudioElement>(null);
   const sessionId = useParams().sessionId ?? '';
+  const latestSessionId = useRef(sessionId);
   if (sessionId === '') {
     displayError('no session found in URL (it should be https://{URL}/session/{sessionId})');
   }
 
   // A new session id deserves a fresh attempt, even if the previous one did not exist.
   useEffect(() => {
+    latestSessionId.current = sessionId;
     setSessionNotFound(false);
     consecutiveNotFound.current = 0;
   }, [sessionId]);
@@ -47,18 +49,18 @@ export function PlayersUi() {
       return;
     }
 
-    // A request already in flight when this effect is torn down resolves against a stale sessionId.
-    // Without this guard, a 404 for the previous session could mark the new one as not found.
-    let outdated = false;
-
     async function resyncOnUi() {
+      // Keyed on the session the request was issued for, not on effect teardown: this effect re-runs
+      // whenever the playing track changes, and dropping a response on every re-run could starve
+      // the consecutive-404 counter below and leave a missing session undetected forever.
+      const requestedFor = sessionId;
       const syncResult = await resyncIfNeeded(
         sessionId,
         audioPlayer.current?.audio?.current?.currentTime ?? null,
         currentTrack,
         shortEffectTrack,
       );
-      if (outdated) {
+      if (requestedFor !== latestSessionId.current) {
         return;
       }
       if (syncResult === 'AbortedRequestError') {
@@ -126,10 +128,7 @@ export function PlayersUi() {
     const id = setInterval(() => {
       resyncOnUi();
     }, SYNC_TRACK_INTERVAL_MS);
-    return () => {
-      outdated = true;
-      clearInterval(id);
-    };
+    return () => clearInterval(id);
   }, [currentTrack, shortEffectTrack, sessionId, sessionNotFound]);
 
   return (

--- a/apps/rpg-maestro-ui/src/app/players-ui/players-ui.tsx
+++ b/apps/rpg-maestro-ui/src/app/players-ui/players-ui.tsx
@@ -15,10 +15,19 @@ import { Typography } from '@mui/material';
 
 export const SYNC_TRACK_INTERVAL_MS = 1000;
 
+/**
+ * How many consecutive 404s before we tell the player the session does not exist and stop polling.
+ * More than one, because a 404 does not always mean "no such session": an ingress can serve 404 for
+ * a few seconds during a rolling backend deploy, and a misconfigured API URL 404s every route. A
+ * single strike would turn those into a permanent, wrong, unrecoverable-without-reload error.
+ */
+export const CONSECUTIVE_NOT_FOUND_BEFORE_GIVING_UP = 3;
+
 export function PlayersUi() {
   const [currentTrack, setCurrentTrack] = useState<PlayingTrack | null>(null);
   const [shortEffectTrack, setShortEffectTrack] = useState<PlayingTrack | null>(null);
   const [sessionNotFound, setSessionNotFound] = useState(false);
+  const consecutiveNotFound = useRef(0);
   const audioPlayer = useRef<H5AudioPlayer>();
   const effectAudioRef = useRef<HTMLAudioElement>(null);
   const sessionId = useParams().sessionId ?? '';
@@ -29,6 +38,7 @@ export function PlayersUi() {
   // A new session id deserves a fresh attempt, even if the previous one did not exist.
   useEffect(() => {
     setSessionNotFound(false);
+    consecutiveNotFound.current = 0;
   }, [sessionId]);
 
   useEffect(() => {
@@ -37,6 +47,10 @@ export function PlayersUi() {
       return;
     }
 
+    // A request already in flight when this effect is torn down resolves against a stale sessionId.
+    // Without this guard, a 404 for the previous session could mark the new one as not found.
+    let outdated = false;
+
     async function resyncOnUi() {
       const syncResult = await resyncIfNeeded(
         sessionId,
@@ -44,14 +58,21 @@ export function PlayersUi() {
         currentTrack,
         shortEffectTrack,
       );
+      if (outdated) {
+        return;
+      }
       if (syncResult === 'AbortedRequestError') {
         return;
       }
       if (syncResult === 'SessionNotFoundError') {
-        // Flipping this re-runs the effect, whose cleanup clears the interval below.
-        setSessionNotFound(true);
+        consecutiveNotFound.current += 1;
+        if (consecutiveNotFound.current >= CONSECUTIVE_NOT_FOUND_BEFORE_GIVING_UP) {
+          // Flipping this re-runs the effect, whose cleanup clears the interval below.
+          setSessionNotFound(true);
+        }
         return;
       }
+      consecutiveNotFound.current = 0;
 
       // Handle current track sync
       const newerServerTrack = syncResult.currentTrack;
@@ -105,7 +126,10 @@ export function PlayersUi() {
     const id = setInterval(() => {
       resyncOnUi();
     }, SYNC_TRACK_INTERVAL_MS);
-    return () => clearInterval(id);
+    return () => {
+      outdated = true;
+      clearInterval(id);
+    };
   }, [currentTrack, shortEffectTrack, sessionId, sessionNotFound]);
 
   return (
@@ -138,7 +162,9 @@ export function PlayersUi() {
 
       {sessionNotFound ? (
         <div
-          role="alert"
+          // deliberately not role="alert": that role is how tests target react-toastify toasts, and
+          // a second match would break strict-mode locators. This is page content, not a toast.
+          role="status"
           style={{ textAlign: 'center', maxWidth: 800, margin: '2rem auto', color: 'var(--text-secondary)', lineHeight: 1.6 }}
         >
           <p style={{ margin: '1rem 0', fontSize: '1.1rem' }}>


### PR DESCRIPTION
Follow-up to #109 (already merged), addressing findings from a code review of it.

## 1. Maestro: a missing session is not terminal there — this was the serious one

`upsertCurrentTrack` **creates** the session in both implementations (`FirestoreTracksDatabase` uses `.set()`, `InMemoryTracksDatabase` has an explicit create branch), so a maestro on a missing session brings it into existence just by playing a track.

#109 stopped the maestro's 5s resync on a 404, and `sessionId` never changes on the soundboard route — so the loop was dead for the whole page lifetime: no drift correction, no picking up play/pause or track changes from another tab or device, until a manual reload.

Now the maestro keeps syncing and reports it once (ref-guarded, so no toast every 5s), with a message that says the session will be created when they play a track.

## 2. Players: require 3 consecutive 404s before giving up

A 404 does not always mean "no such session" — an ingress can serve 404 for a few seconds during a rolling deploy, and a misconfigured `VITE_RPG_MAESTRO_API_URL` 404s every route. #109 made a single strike permanent and unrecoverable without a reload, which is strictly worse than the old self-healing behaviour for those cases.

## 3. Players: guard against stale in-flight responses

On SPA navigation between session ids the component is reused, so an in-flight 404 for the previous id could mark the new one as missing.

My first attempt used a per-effect-run `outdated` flag, which was wrong: the effect re-runs whenever the playing track changes, so benign churn discarded responses and could starve the counter in item 2. It now compares the sessionId a request was issued for against the latest one, so churn drops nothing while cross-session staleness is still ignored.

## 4. `role="status"`, not `role="alert"`, for the panel

`role="alert"` is how this suite targets react-toastify toasts (per `CLAUDE.md`). A second match risks strict-mode locator violations, and it made #109's "no error toast" assertion vacuous — it could only ever match the panel's own text. The assertion is now `expect(page.getByRole('alert')).toHaveCount(0)`, which actually verifies no toast fired.

## Verification

- `tsc --noEmit`: no new errors (8 pre-existing, none in touched files)
- `nx lint rpg-maestro-ui`: 0 errors
- new test covering transient-404 recovery; verified it is load-bearing by setting the threshold to 1, which fails it
- the stop-polling test no longer asserts an exact request count — React can fire one more tick before the state update tears the loop down. It drains that straggler, then asserts the loop goes quiet with a bounded total

### Honest note on flakiness

While testing I saw the stop-polling test fail intermittently, and I could not fully explain it. What I established:

- it passes consistently in isolation and at file level once the environment is settled (10+ consecutive passes across several batches)
- the failures clustered in time with unambiguously environmental ones — several runs failed at `waitForAppToBeReady` because the backend never came up, which no frontend change can cause
- adding console instrumentation made it pass 100% of the time, so I could never capture a failing run's state

I could not prove a code-level race, and the two brittle things I did find (the `outdated` guard and the exact-count assertion) are fixed above. Flagging it so CI is the arbiter rather than my local box.

### Pre-existing, unrelated

- Full suite locally: 4 failed / 7 passed, identical in count and membership to clean `main` — `POST /maestro/sessions` returns 401, looks like fake-IdP/auth fixture setup. Because `players-ui.spec.ts` is `mode: 'serial'`, that failure short-circuits the file and both new tests show as "did not run" locally. Worth fixing separately; until then these tests may not actually execute in CI either. Moving the mock-only test to its own file would decouple it if you want that.
- The review also flagged `lines-and-columns` being promoted to a prod dependency in `package.json`. That is a pre-existing uncommitted change in the working tree, not part of this PR or #109 — it looks like fallout from an earlier local `npm install` and probably wants reverting.