### PR TITLE
feat(cache): one active cache tier, chosen by health

### DIFF
--- a/apps/rpg-maestro/src/app/infrastructure/cache/cache-tiers.factory.ts
+++ b/apps/rpg-maestro/src/app/infrastructure/cache/cache-tiers.factory.ts
@@ -1,0 +1,44 @@
+import { Logger } from '@nestjs/common';
+import Keyv from 'keyv';
+import KeyvRedis from '@keyv/redis';
+import { CacheTier } from './resilient-cache';
+
+const logger = new Logger('CacheTiers');
+
+/**
+ * Cache backends in priority order, from the environment:
+ * - `CACHE_REDIS_URL` — the self-hosted Redis, primary;
+ * - `CACHE_FALLBACK_REDIS_URL` — the managed Redis-compatible service, used with the exact same
+ *   read-through logic while the primary is unreachable.
+ *
+ * With neither set the cache stays in-process, which is what local dev and the e2e tests want.
+ */
+export function createCacheTiers<T>(namespace: string, ttl: number): CacheTier<T>[] {
+  const tiers: CacheTier<T>[] = [];
+
+  const primaryUrl = process.env.CACHE_REDIS_URL;
+  if (primaryUrl) {
+    tiers.push({ name: 'redis', store: redisStore<T>('redis', primaryUrl, namespace, ttl) });
+  }
+
+  const fallbackUrl = process.env.CACHE_FALLBACK_REDIS_URL;
+  if (fallbackUrl) {
+    tiers.push({ name: 'redis-fallback', store: redisStore<T>('redis-fallback', fallbackUrl, namespace, ttl) });
+  }
+
+  if (tiers.length === 0) {
+    logger.log(`no cache backend configured, "${namespace}" is cached in-process`);
+    tiers.push({ name: 'in-memory', store: new Keyv<T>({ namespace, ttl }) });
+  }
+
+  return tiers;
+}
+
+function redisStore<T>(name: string, url: string, namespace: string, ttl: number): Keyv<T> {
+  logger.log(`using "${name}" as a cache backend for "${namespace}"`);
+  const store = new Keyv<T>({ store: new KeyvRedis(url), namespace, ttl });
+  // Keyv surfaces connection problems as 'error' events; without a listener node would crash the
+  // process. ResilientCache reacts to rejected operations, so logging is all that is needed here.
+  store.on('error', (error) => logger.warn(`cache tier "${name}" emitted an error`, error));
+  return store;
+}

--- a/apps/rpg-maestro/src/app/infrastructure/cache/resilient-cache.spec.ts
+++ b/apps/rpg-maestro/src/app/infrastructure/cache/resilient-cache.spec.ts
@@ -1,0 +1,185 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { CacheStore, CacheTier, FAILURE_THRESHOLD, PROBE_INTERVAL_MS, ResilientCache } from './resilient-cache';
+
+class FakeStore implements CacheStore<string> {
+  readonly entries = new Map<string, string>();
+  /** When true every operation rejects, as a real backend would while it is unreachable. */
+  down = false;
+  readonly calls: string[] = [];
+
+  async get(key: string): Promise<string | undefined> {
+    this.record('get');
+    return this.entries.get(key);
+  }
+
+  async set(key: string, value: string): Promise<unknown> {
+    this.record('set');
+    return this.entries.set(key, value);
+  }
+
+  async delete(key: string): Promise<unknown> {
+    this.record('delete');
+    return this.entries.delete(key);
+  }
+
+  async clear(): Promise<unknown> {
+    this.record('clear');
+    this.entries.clear();
+    return undefined;
+  }
+
+  private record(operation: string): void {
+    this.calls.push(operation);
+    if (this.down) {
+      throw new Error(`backend is down, cannot ${operation}`);
+    }
+  }
+}
+
+describe('ResilientCache', () => {
+  let primary: FakeStore;
+  let fallback: FakeStore;
+  let cache: ResilientCache<string>;
+
+  const knockOutPrimary = async (): Promise<void> => {
+    primary.down = true;
+    for (let i = 0; i < FAILURE_THRESHOLD; i++) {
+      await cache.get('any-key');
+    }
+  };
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    primary = new FakeStore();
+    fallback = new FakeStore();
+    const tiers: CacheTier<string>[] = [
+      { name: 'primary', store: primary },
+      { name: 'fallback', store: fallback },
+    ];
+    cache = new ResilientCache(tiers);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('rejects duplicate tier names', () => {
+    expect(
+      () =>
+        new ResilientCache([
+          { name: 'same', store: new FakeStore() },
+          { name: 'same', store: new FakeStore() },
+        ])
+    ).toThrow(/duplicate cache tier name/);
+  });
+
+  it('serves reads and writes from the primary while it is healthy', async () => {
+    await cache.set('session-1', 'tavern');
+
+    expect(primary.entries.get('session-1')).toBe('tavern');
+    await expect(cache.get('session-1')).resolves.toBe('tavern');
+  });
+
+  it('invalidates the dormant fallback on write instead of populating it', async () => {
+    fallback.entries.set('session-1', 'stale');
+
+    await cache.set('session-1', 'tavern');
+
+    expect(primary.entries.get('session-1')).toBe('tavern');
+    expect(fallback.entries.has('session-1')).toBe(false);
+  });
+
+  it('does not cascade to the fallback on a plain miss', async () => {
+    fallback.entries.set('session-1', 'stale');
+
+    await expect(cache.get('session-1')).resolves.toBeUndefined();
+    expect(fallback.calls).not.toContain('get');
+  });
+
+  it('moves to the fallback after the primary fails repeatedly, with the same read-through logic', async () => {
+    await knockOutPrimary();
+
+    await cache.set('session-1', 'tavern');
+
+    expect(fallback.entries.get('session-1')).toBe('tavern');
+    await expect(cache.get('session-1')).resolves.toBe('tavern');
+  });
+
+  it('stops calling the primary while it is in cooldown', async () => {
+    await knockOutPrimary();
+    const callsWhenKnockedOut = primary.calls.length;
+
+    await cache.get('session-1');
+    await cache.set('session-1', 'tavern');
+
+    expect(primary.calls.length).toBe(callsWhenKnockedOut);
+  });
+
+  it('clears the recovered primary before serving anything from it', async () => {
+    primary.entries.set('session-1', 'stale-from-before-the-outage');
+    await knockOutPrimary();
+    primary.down = false;
+
+    vi.advanceTimersByTime(PROBE_INTERVAL_MS);
+    const value = await cache.get('session-1');
+
+    expect(value).toBeUndefined();
+    expect(primary.entries.size).toBe(0);
+    expect(primary.calls).toContain('clear');
+  });
+
+  it('keeps the primary out of rotation when the recovery probe fails', async () => {
+    await knockOutPrimary();
+
+    vi.advanceTimersByTime(PROBE_INTERVAL_MS);
+    await cache.set('session-1', 'tavern');
+
+    expect(fallback.entries.get('session-1')).toBe('tavern');
+    expect(primary.entries.size).toBe(0);
+  });
+
+  it('degrades to no cache at all when every tier is down', async () => {
+    await knockOutPrimary();
+    fallback.down = true;
+    for (let i = 0; i < FAILURE_THRESHOLD; i++) {
+      await cache.get('any-key');
+    }
+    const callsWhenAllDown = primary.calls.length + fallback.calls.length;
+
+    await expect(cache.set('session-1', 'tavern')).resolves.toBeUndefined();
+    await expect(cache.get('session-1')).resolves.toBeUndefined();
+    expect(primary.calls.length + fallback.calls.length).toBe(callsWhenAllDown);
+  });
+
+  it('does not take a tier out of rotation for failures that are not consecutive', async () => {
+    for (let i = 0; i < FAILURE_THRESHOLD * 2; i++) {
+      primary.down = true;
+      await cache.get('session-1');
+      primary.down = false;
+      await cache.get('session-1');
+    }
+
+    await cache.set('session-1', 'tavern');
+    expect(primary.entries.get('session-1')).toBe('tavern');
+  });
+
+  it('deletes the key from every healthy tier', async () => {
+    primary.entries.set('session-1', 'tavern');
+    fallback.entries.set('session-1', 'stale');
+
+    await cache.delete('session-1');
+
+    expect(primary.entries.has('session-1')).toBe(false);
+    expect(fallback.entries.has('session-1')).toBe(false);
+  });
+
+  it('behaves like a plain cache when a single tier is configured', async () => {
+    const only = new FakeStore();
+    const single = new ResilientCache<string>([{ name: 'in-memory', store: only }]);
+
+    await single.set('session-1', 'tavern');
+
+    await expect(single.get('session-1')).resolves.toBe('tavern');
+    await expect(single.get('unknown')).resolves.toBeUndefined();
+  });
+});

--- a/apps/rpg-maestro/src/app/infrastructure/cache/resilient-cache.ts
+++ b/apps/rpg-maestro/src/app/infrastructure/cache/resilient-cache.ts
@@ -1,0 +1,160 @@
+import { Logger } from '@nestjs/common';
+import ms from 'ms';
+
+/**
+ * Minimal contract a cache backend must satisfy. `Keyv` matches it structurally, which keeps
+ * {@link ResilientCache} testable without a real Redis.
+ */
+export interface CacheStore<T> {
+  get(key: string): Promise<T | undefined>;
+  set(key: string, value: T): Promise<unknown>;
+  delete(key: string): Promise<unknown>;
+  clear(): Promise<unknown>;
+}
+
+export interface CacheTier<T> {
+  /** Used in logs only. */
+  readonly name: string;
+  readonly store: CacheStore<T>;
+}
+
+/** Consecutive failures before a tier is taken out of rotation. */
+export const FAILURE_THRESHOLD = 3;
+
+/** How long a tier stays out of rotation before the next operation probes it again. */
+export const PROBE_INTERVAL_MS = ms('30s');
+
+interface TierState {
+  consecutiveFailures: number;
+  /** Epoch ms before which the tier must not be called. `null` means the tier is healthy. */
+  unhealthyUntil: number | null;
+}
+
+/**
+ * A cache spread over several backends where exactly **one tier is active at a time**, picked by
+ * health in declaration order. There is no cascade: a miss on the active tier is a miss, and the
+ * caller falls back to the database. When every tier is down the cache degrades to no cache at all
+ * rather than to a slower one.
+ *
+ * Two rules keep a dormant tier from waking up with stale data, given that writes only ever reach
+ * the active tier:
+ * - a write invalidates the key on every other healthy tier (write to one, delete from all);
+ * - a tier that failed and later recovers has its namespace cleared before it serves anything,
+ *   since it missed every invalidation during the outage.
+ */
+export class ResilientCache<T> {
+  private readonly logger = new Logger(ResilientCache.name);
+  private readonly states = new Map<string, TierState>();
+
+  constructor(private readonly tiers: CacheTier<T>[]) {
+    for (const tier of tiers) {
+      if (this.states.has(tier.name)) {
+        throw new Error(`duplicate cache tier name "${tier.name}", tier names must be unique`);
+      }
+      this.states.set(tier.name, { consecutiveFailures: 0, unhealthyUntil: null });
+    }
+  }
+
+  async get(key: string): Promise<T | undefined> {
+    const tier = await this.activeTier();
+    if (!tier) {
+      return undefined;
+    }
+    try {
+      const value = await tier.store.get(key);
+      this.stateOf(tier).consecutiveFailures = 0;
+      return value;
+    } catch (error) {
+      this.recordFailure(tier, error);
+      return undefined;
+    }
+  }
+
+  async set(key: string, value: T): Promise<void> {
+    const active = await this.activeTier();
+    await Promise.all(
+      this.tiers.map((tier) => {
+        if (tier === active) {
+          return this.run(tier, () => tier.store.set(key, value));
+        }
+        // A tier in cooldown is skipped on purpose: it gets cleared on recovery anyway, so paying a
+        // timeout on every write to invalidate it would be pure latency.
+        return this.isHealthy(tier) ? this.run(tier, () => tier.store.delete(key)) : Promise.resolve();
+      })
+    );
+  }
+
+  async delete(key: string): Promise<void> {
+    await this.activeTier();
+    await Promise.all(
+      this.tiers.map((tier) =>
+        this.isHealthy(tier) ? this.run(tier, () => tier.store.delete(key)) : Promise.resolve()
+      )
+    );
+  }
+
+  /**
+   * First tier usable right now, in declaration order. Probes and clears recovered tiers on the way,
+   * so a tier that comes back up is never read from before it is clean.
+   */
+  private async activeTier(): Promise<CacheTier<T> | undefined> {
+    for (const tier of this.tiers) {
+      const state = this.stateOf(tier);
+      if (state.unhealthyUntil === null) {
+        return tier;
+      }
+      if (Date.now() < state.unhealthyUntil) {
+        continue;
+      }
+      // `clear` doubles as the connectivity probe and as the wipe of data that went stale while the
+      // tier was missing invalidations.
+      try {
+        await tier.store.clear();
+        this.logger.log(`cache tier "${tier.name}" recovered, its namespace was cleared`);
+        state.consecutiveFailures = 0;
+        state.unhealthyUntil = null;
+        return tier;
+      } catch (error) {
+        this.recordFailure(tier, error);
+      }
+    }
+    return undefined;
+  }
+
+  private async run(tier: CacheTier<T>, operation: () => Promise<unknown>): Promise<void> {
+    try {
+      await operation();
+      this.stateOf(tier).consecutiveFailures = 0;
+    } catch (error) {
+      this.recordFailure(tier, error);
+    }
+  }
+
+  private isHealthy(tier: CacheTier<T>): boolean {
+    return this.stateOf(tier).unhealthyUntil === null;
+  }
+
+  private recordFailure(tier: CacheTier<T>, error: unknown): void {
+    const state = this.stateOf(tier);
+    state.consecutiveFailures++;
+    if (state.unhealthyUntil !== null) {
+      state.unhealthyUntil = Date.now() + PROBE_INTERVAL_MS;
+      return;
+    }
+    if (state.consecutiveFailures >= FAILURE_THRESHOLD) {
+      state.unhealthyUntil = Date.now() + PROBE_INTERVAL_MS;
+      this.logger.warn(
+        `cache tier "${tier.name}" failed ${state.consecutiveFailures} times in a row, taking it out of rotation for ${PROBE_INTERVAL_MS}ms`,
+        error
+      );
+    }
+  }
+
+  private stateOf(tier: CacheTier<T>): TierState {
+    const state = this.states.get(tier.name);
+    if (!state) {
+      throw new Error(`no state for cache tier "${tier.name}", it was not declared at construction`);
+    }
+    return state;
+  }
+}

--- a/apps/rpg-maestro/src/app/sessions/sessions.cache.ts
+++ b/apps/rpg-maestro/src/app/sessions/sessions.cache.ts
@@ -1,15 +1,13 @@
-import Keyv from 'keyv';
 import ms from 'ms';
 import { SessionPlayingTracks } from '@rpg-maestro/rpg-maestro-api-contract';
+import { ResilientCache } from '../infrastructure/cache/resilient-cache';
+import { createCacheTiers } from '../infrastructure/cache/cache-tiers.factory';
 
 export class SessionsCache {
-  private cache: Keyv<SessionPlayingTracks>;
+  private cache: ResilientCache<SessionPlayingTracks>;
 
   constructor() {
-    this.cache = new Keyv<SessionPlayingTracks>({
-      namespace: 'rpg_maestro_sessions',
-      ttl: ms('1 day'),
-    });
+    this.cache = new ResilientCache(createCacheTiers<SessionPlayingTracks>('rpg_maestro_sessions', ms('1 day')));
   }
 
   async get(sessionId: string): Promise<SessionPlayingTracks | undefined> {

--- a/apps/rpg-maestro/src/app/users-management/users.cache.ts
+++ b/apps/rpg-maestro/src/app/users-management/users.cache.ts
@@ -1,15 +1,13 @@
-import Keyv from 'keyv';
 import ms from 'ms';
 import { User, UserID } from '@rpg-maestro/rpg-maestro-api-contract';
+import { ResilientCache } from '../infrastructure/cache/resilient-cache';
+import { createCacheTiers } from '../infrastructure/cache/cache-tiers.factory';
 
 export class UsersCache {
-  private cache: Keyv<User>;
+  private cache: ResilientCache<User>;
 
   constructor() {
-    this.cache = new Keyv<User>({
-      namespace: 'rpg_maestro_users',
-      ttl: ms('1 day'),
-    });
+    this.cache = new ResilientCache(createCacheTiers<User>('rpg_maestro_users', ms('1 day')));
   }
 
   async get(userId: UserID): Promise<User | undefined> {

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -242,6 +242,43 @@ DatabaseModule
 
 ---
 
+## Caching Layer
+
+Read-through caches sit in front of Firestore to stay under its quotas, since audience pages poll
+continuously. `SessionsCache` (`rpg_maestro_sessions`) and `UsersCache` (`rpg_maestro_users`) both
+have a 1 day TTL and wrap `ResilientCache`
+(`infrastructure/cache/resilient-cache.ts`).
+
+**One active tier at a time.** Backends are declared in priority order and the first healthy one
+serves everything. There is no cascade between them: a miss on the active tier is a miss, and the
+caller goes to the database.
+
+```
+CACHE_REDIS_URL           → 'redis'           self-hosted, primary
+CACHE_FALLBACK_REDIS_URL  → 'redis-fallback'  managed service, used while the primary is down
+neither set               → 'in-memory'       in-process Keyv (local dev, e2e tests)
+
+get(key):  active tier ? (hit → return | miss → caller hits DB, then set) : caller hits DB
+```
+
+When every configured tier is down the cache degrades to **no cache at all**, not to a slower one —
+the database absorbs the traffic until a tier comes back.
+
+**Health switching.** `FAILURE_THRESHOLD` consecutive failures take a tier out of rotation for
+`PROBE_INTERVAL_MS`; after that the next operation probes it. Without this, an outage that lasts
+hours would cost a connection timeout on every single request.
+
+**Two rules keep a dormant tier from waking up with stale data**, given that writes only ever reach
+the active tier:
+
+1. *Write to one, delete from all* — a `set` also invalidates the key on every other healthy tier.
+   Tiers in cooldown are skipped on purpose; rule 2 covers them.
+2. *Clear on recovery* — a tier that failed and later comes back missed every invalidation during
+   the outage, so its namespace is cleared before it serves anything. The clear doubles as the
+   connectivity probe. A tier that was never unhealthy is not cleared, so deploys keep a warm cache.
+
+---
+
 ## Authentication Flow
 
 ### Production (Auth0)
@@ -332,3 +369,4 @@ Client reconstructs current position as `(Date.now() - playTimestamp) / 1000 + t
 | Fake IDP for dev | No Auth0 tenant required for local dev |
 | MUI dark theme | Fits the RPG atmosphere; consistent component library |
 | Role enum (MAESTRO/MINSTREL/ADMIN) | Granular access control without OAuth scopes |
+| One active cache tier, no cascade | A Redis outage lasts hours here; dual-writing every tier costs latency on every request to guard against a rare event. Health switching + clear-on-recovery gets the same safety |

--- a/docs/dev-guide.md
+++ b/docs/dev-guide.md
@@ -62,6 +62,11 @@ npx nx deploy rpg-maestro
 | `apps/audio-file-uploader/.env.e2e-tests` | E2E test runner |
 | `apps/rpg-maestro-ui/.env` | Vite dev server (create from `.env.example` if present) |
 
+**Cache backends** (backend, both optional): `CACHE_REDIS_URL` selects the primary Redis and
+`CACHE_FALLBACK_REDIS_URL` the managed service used while the primary is down. With neither set the
+cache stays in-process, which is what local dev and the e2e tests use. See
+[architecture.md](architecture.md) for the tier switching rules.
+
 ## Adding a New Feature — Checklist
 
 1. **Backend module** — create under `apps/rpg-maestro/src/app/<module>/`

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@distube/ytdl-core": "^4.16.10",
         "@emotion/react": "^11.13.3",
         "@emotion/styled": "^11.13.0",
+        "@keyv/redis": "^5.1.6",
         "@mui/icons-material": "^6.5.0",
         "@mui/material": "^6.1.6",
         "@mui/x-data-grid": "^7.22.1",
@@ -5202,6 +5203,23 @@
       },
       "peerDependencies": {
         "tslib": "2"
+      }
+    },
+    "node_modules/@keyv/redis": {
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/@keyv/redis/-/redis-5.1.6.tgz",
+      "integrity": "sha512-eKvW6pspvVaU5dxigaIDZr635/Uw6urTXL3gNbY9WTR8d3QigZQT+r8gxYSEOsw4+1cCBsC4s7T2ptR0WC9LfQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@redis/client": "^5.10.0",
+        "cluster-key-slot": "^1.1.2",
+        "hookified": "^1.13.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "keyv": "^5.6.0"
       }
     },
     "node_modules/@keyv/serialize": {
@@ -10528,6 +10546,30 @@
       "integrity": "sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==",
       "devOptional": true,
       "license": "BSD-3-Clause"
+    },
+    "node_modules/@redis/client": {
+      "version": "5.12.1",
+      "resolved": "https://registry.npmjs.org/@redis/client/-/client-5.12.1.tgz",
+      "integrity": "sha512-7aPGWeqA3uFm43o19umzdl16CEjK/JQGtSXVPevplTaOU3VJA/rseBC1QvYUz9lLDIMBimc4SW/zrW4S89BaCA==",
+      "license": "MIT",
+      "dependencies": {
+        "cluster-key-slot": "1.1.2"
+      },
+      "engines": {
+        "node": ">= 18.19.0"
+      },
+      "peerDependencies": {
+        "@node-rs/xxhash": "^1.1.0",
+        "@opentelemetry/api": ">=1 <2"
+      },
+      "peerDependenciesMeta": {
+        "@node-rs/xxhash": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        }
+      }
     },
     "node_modules/@remix-run/router": {
       "version": "1.6.2",
@@ -18160,24 +18202,6 @@
         "node": ">= 16"
       }
     },
-    "node_modules/chokidar": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
-      "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "readdirp": "^4.0.1"
-      },
-      "engines": {
-        "node": ">= 14.16.0"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
     "node_modules/chrome-trace-event": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/chrome-trace-event/-/chrome-trace-event-1.0.4.tgz",
@@ -18547,6 +18571,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/cluster-key-slot": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.2.tgz",
+      "integrity": "sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/co": {
@@ -20769,7 +20802,7 @@
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
       "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "iconv-lite": "^0.6.2"
@@ -24535,6 +24568,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/hookified": {
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/hookified/-/hookified-1.15.1.tgz",
+      "integrity": "sha512-MvG/clsADq1GPM2KGo2nyfaWVyn9naPiXrqIe4jYjXNZQt238kWyOGrsyc/DmRAQ+Re6yeo6yX/yoNCG5KAEVg==",
+      "license": "MIT"
+    },
     "node_modules/hookpoint": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/hookpoint/-/hookpoint-4.1.0.tgz",
@@ -25219,7 +25258,7 @@
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
       "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
@@ -36135,22 +36174,6 @@
       },
       "engines": {
         "node": ">= 6"
-      }
-    },
-    "node_modules/readdirp": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
-      "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">= 14.18.0"
-      },
-      "funding": {
-        "type": "individual",
-        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/recast": {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "@distube/ytdl-core": "^4.16.10",
     "@emotion/react": "^11.13.3",
     "@emotion/styled": "^11.13.0",
+    "@keyv/redis": "^5.1.6",
     "@mui/icons-material": "^6.5.0",
     "@mui/material": "^6.1.6",
     "@mui/x-data-grid": "^7.22.1",


### PR DESCRIPTION
## What

Replaces the bare `Keyv` instances behind `SessionsCache` / `UsersCache` with `ResilientCache`: backends are declared in priority order and **the first healthy one serves everything**. No cascade between tiers — a miss on the active tier is a miss, and the caller falls back to the database. When every tier is down the cache degrades to **no cache at all** rather than to a slower one.

```
CACHE_REDIS_URL           → 'redis'           self-hosted, primary
CACHE_FALLBACK_REDIS_URL  → 'redis-fallback'  managed service, used while the primary is down
neither set               → 'in-memory'       in-process Keyv (local dev, e2e tests)
```

## Why not dual-write every tier

Redis here is self-hosted; a crash means hours of downtime until a manual reboot. Writing to every tier on every request pays a permanent latency cost to guard against a rare event. Two rules buy the same safety:

1. **Write to one, delete from all** — a `set` invalidates the key on every other *healthy* tier, so a dormant tier cannot hold a value that has since changed. Tiers in cooldown are skipped on purpose; rule 2 covers them.
2. **Clear on recovery** — a tier that failed missed every invalidation during the outage, so its namespace is cleared before it serves anything. The `clear()` doubles as the connectivity probe. A tier that was never unhealthy is not cleared, so deploys keep a warm cache.

A circuit breaker keeps a dead backend from costing a connection timeout on every request: 3 consecutive failures take a tier out of rotation for 30s, after which the next operation probes it.

## Notes

- **No behaviour change on merge** — nothing sets the new env vars yet, so the cache stays in-process exactly as today.
- `SessionsCache` / `UsersCache` keep their existing interface; `sessions.service.ts` and `users.service.ts` are untouched.
- Assumes the managed fallback is Redis-compatible (both tiers are `@keyv/redis`, differing only by URL).
- New dependency: `@keyv/redis`.

## Test plan

- 12 unit tests in `resilient-cache.spec.ts` covering: reads/writes on the primary, dormant-tier invalidation on write, no cascade on a plain miss, switchover after repeated failures, no calls during cooldown, clear-before-serve on recovery, failed recovery probe, all-tiers-down, non-consecutive failures not tripping the breaker, and the single-tier case.
- `nx test rpg-maestro` green: 47 tests, 11 files.