### PR TITLE
fix(cache): prefix redis keys once, and refuse to start if the namespace is lost

### DIFF
--- a/apps/rpg-maestro/src/app/infrastructure/cache/cache-tiers.factory.spec.ts
+++ b/apps/rpg-maestro/src/app/infrastructure/cache/cache-tiers.factory.spec.ts
@@ -1,0 +1,80 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import Keyv from 'keyv';
+import KeyvRedis from '@keyv/redis';
+import ms from 'ms';
+import { createCacheTiers } from './cache-tiers.factory';
+import { CacheTier } from './resilient-cache';
+
+/** The store a tier was built with, as the concrete types the assertions need. */
+const storesOf = (tier: CacheTier<string>): { keyv: Keyv<string>; redis: KeyvRedis<unknown> } => {
+  const keyv = tier.store as Keyv<string>;
+  return { keyv, redis: keyv.store as KeyvRedis<unknown> };
+};
+
+describe('createCacheTiers', () => {
+  const NAMESPACE = 'rpg_maestro_sessions';
+  const TTL = ms('1 day');
+
+  beforeEach(() => {
+    delete process.env.CACHE_REDIS_URL;
+    delete process.env.CACHE_FALLBACK_REDIS_URL;
+  });
+
+  afterEach(() => {
+    delete process.env.CACHE_REDIS_URL;
+    delete process.env.CACHE_FALLBACK_REDIS_URL;
+  });
+
+  it('caches in-process when no backend is configured', () => {
+    const tiers = createCacheTiers<string>(NAMESPACE, TTL);
+
+    expect(tiers.map((tier) => tier.name)).toEqual(['in-memory']);
+  });
+
+  it('declares the primary before the fallback', () => {
+    process.env.CACHE_REDIS_URL = 'redis://localhost:6399';
+    process.env.CACHE_FALLBACK_REDIS_URL = 'rediss://localhost:6400';
+
+    const tiers = createCacheTiers<string>(NAMESPACE, TTL);
+
+    expect(tiers.map((tier) => tier.name)).toEqual(['redis', 'redis-fallback']);
+  });
+
+  it('uses the fallback alone when only it is configured', () => {
+    process.env.CACHE_FALLBACK_REDIS_URL = 'rediss://localhost:6400';
+
+    const tiers = createCacheTiers<string>(NAMESPACE, TTL);
+
+    expect(tiers.map((tier) => tier.name)).toEqual(['redis-fallback']);
+  });
+
+  it('gives the namespace to the redis store, so clearing a recovered tier cannot FLUSHDB', () => {
+    process.env.CACHE_REDIS_URL = 'redis://localhost:6399';
+
+    const { redis } = storesOf(createCacheTiers<string>(NAMESPACE, TTL)[0]);
+
+    // KeyvRedis.clear() scans `<namespace>::*` when it has a namespace and FLUSHDB's when it has
+    // none, and ResilientCache clears a tier on every recovery.
+    expect(redis.namespace).toBe(NAMESPACE);
+  });
+
+  it('prefixes stored keys with the namespace exactly once', () => {
+    process.env.CACHE_REDIS_URL = 'redis://localhost:6399';
+
+    const { keyv, redis } = storesOf(createCacheTiers<string>(NAMESPACE, TTL)[0]);
+
+    // Keyv leaves the key untouched, so the only prefix is the one KeyvRedis applies. Without this
+    // the stored key would be `rpg_maestro_sessions::rpg_maestro_sessions:Kj2Yh`.
+    expect(keyv.useKeyPrefix).toBe(false);
+    expect(redis.createKeyPrefix('Kj2Yh', redis.namespace)).toBe('rpg_maestro_sessions::Kj2Yh');
+  });
+
+  it('keeps namespaces apart so one tier recovery cannot clear another cache', () => {
+    process.env.CACHE_REDIS_URL = 'redis://localhost:6399';
+
+    const sessions = storesOf(createCacheTiers<string>('rpg_maestro_sessions', TTL)[0]);
+    const users = storesOf(createCacheTiers<string>('rpg_maestro_users', TTL)[0]);
+
+    expect(sessions.redis.namespace).not.toBe(users.redis.namespace);
+  });
+});

--- a/apps/rpg-maestro/src/app/infrastructure/cache/cache-tiers.factory.ts
+++ b/apps/rpg-maestro/src/app/infrastructure/cache/cache-tiers.factory.ts
@@ -36,9 +36,31 @@ export function createCacheTiers<T>(namespace: string, ttl: number): CacheTier<T
 
 function redisStore<T>(name: string, url: string, namespace: string, ttl: number): Keyv<T> {
   logger.log(`using "${name}" as a cache backend for "${namespace}"`);
-  const store = new Keyv<T>({ store: new KeyvRedis(url), namespace, ttl });
+  const redis = new KeyvRedis(url);
+  // `useKeyPrefix: false` leaves the prefixing to KeyvRedis. Keyv would otherwise add its own on
+  // top, for keys shaped `<namespace>::<namespace>:<key>`.
+  const store = new Keyv<T>({ store: redis, namespace, ttl, useKeyPrefix: false });
+  assertNamespaceReachedRedis(redis, namespace);
   // Keyv surfaces connection problems as 'error' events; without a listener node would crash the
   // process. ResilientCache reacts to rejected operations, so logging is all that is needed here.
   store.on('error', (error) => logger.warn(`cache tier "${name}" emitted an error`, error));
   return store;
+}
+
+/**
+ * The namespace has to reach KeyvRedis itself, not just the Keyv wrapper: `KeyvRedis.clear()` scans
+ * `<namespace>::*` when it has a namespace, but falls back to `FLUSHDB` when it does not. Since
+ * {@link ResilientCache} clears a tier every time it recovers, an unset namespace would wipe every
+ * other namespace on the server — and anything else sharing it — on each recovery.
+ *
+ * Keyv propagates the namespace to its store today; this asserts it rather than trusting it, so an
+ * upstream change fails at boot instead of silently escalating a recovery into a full flush.
+ */
+function assertNamespaceReachedRedis(redis: KeyvRedis<unknown>, namespace: string): void {
+  if (redis.namespace !== namespace) {
+    throw new Error(
+      `cache namespace "${namespace}" did not reach the redis store (got "${redis.namespace}"), ` +
+        `refusing to start: clearing a recovered tier would FLUSHDB instead of scoping to the namespace`
+    );
+  }
 }


### PR DESCRIPTION
Follow-up to #111, from looking at the keys it actually wrote on the homelab host:

```
rpg_maestro_sessions::rpg_maestro_sessions:Kj2Yh
rpg_maestro_users::rpg_maestro_users:roman.acevedo62@gmail.com
```

Keyv prefixes the key with its namespace *and* propagates the namespace to KeyvRedis, which prefixes it again. `useKeyPrefix: false` leaves the prefixing to KeyvRedis alone, giving `rpg_maestro_sessions::Kj2Yh`.

## The part that isn't cosmetic

`KeyvRedis.clear()` branches on whether it has a namespace (`node_modules/@keyv/redis/dist/index.cjs:728`):

```js
if (!this._namespace && this._noNamespaceAffectsAll) {
  await client.flushDb();
  return;
}
const match = this._namespace ? `${this._namespace}${this._keyPrefixSeparator}*` : '*';
```

`ResilientCache` clears a tier **every time it recovers**. So if the namespace ever failed to reach KeyvRedis, each recovery would `FLUSHDB` — wiping the other namespace and anything else sharing that server — instead of scoping to its own keys. Keyv propagates it today, and the naive version of this fix (setting the namespace on `KeyvRedis` and not on `Keyv`) would have broken exactly that, because `Keyv` assigns `store.namespace = this._namespace` unconditionally, including when it is `undefined`.

So the namespace is now asserted at construction rather than trusted: an upstream change fails at boot instead of silently escalating a recovery into a full flush.

## Notes

- Existing keys are orphaned by the format change — for a cache that is one Firestore read each, then they age out with the TTL.
- No behaviour change for the in-memory tier.

## Test plan

- 6 new unit tests in `cache-tiers.factory.spec.ts`: tier ordering and naming for each env combination, the namespace reaching the redis store, single prefixing (`rpg_maestro_sessions::Kj2Yh` via `createKeyPrefix`), and sessions/users namespaces staying distinct.
- `nx test rpg-maestro` green: 53 tests, 12 files.
- **Not** verified against a real server — there is no Docker daemon on this workstation, so the key format is pinned through `KeyvRedis.createKeyPrefix` rather than by round-tripping a value. Worth one `valkey-cli --scan` on the host after deploy to confirm the single prefix.