### PR TITLE
fix(sync): resolve the playhead server-side and order writes by revision

### DIFF
--- a/apps/rpg-maestro-ui/src/app/admin-ui/admin-board.stories.tsx
+++ b/apps/rpg-maestro-ui/src/app/admin-ui/admin-board.stories.tsx
@@ -102,6 +102,8 @@ const sessions: SessionPlayingTracks[] = [
       now - 120000,
       22000
     ),
+    shortEffectTrack: null,
+    revision: 1,
   },
   {
     sessionId: 'session-beta',
@@ -114,10 +116,14 @@ const sessions: SessionPlayingTracks[] = [
       now - 60000,
       80000
     ),
+    shortEffectTrack: null,
+    revision: 1,
   },
   {
     sessionId: 'session-gamma',
     currentTrack: null,
+    shortEffectTrack: null,
+    revision: 0,
   },
   {
     sessionId: 'session-delta',
@@ -130,6 +136,8 @@ const sessions: SessionPlayingTracks[] = [
       now - 90000,
       15000
     ),
+    shortEffectTrack: null,
+    revision: 1,
   },
   {
     sessionId: 'session-epsilon',
@@ -142,6 +150,8 @@ const sessions: SessionPlayingTracks[] = [
       now - 30000,
       5000
     ),
+    shortEffectTrack: null,
+    revision: 1,
   },
 ];
 

--- a/apps/rpg-maestro-ui/src/app/maestro-ui/maestro-api.ts
+++ b/apps/rpg-maestro-ui/src/app/maestro-ui/maestro-api.ts
@@ -1,8 +1,8 @@
 import { displayError } from '../error-utils';
 import {
   ChangeSessionPlayingTracksRequest,
-  PlayingTrack,
   SessionPlayingTracks,
+  SessionPlayingTracksResponse,
   Track,
   TrackCreation,
   TrackCreationFromYoutubeDto,
@@ -16,6 +16,7 @@ import {
 } from '@rpg-maestro/rpg-maestro-api-contract';
 import { authenticatedFetch } from '../utils/authenticated-fetch';
 import { rpgMaestroApiUrl } from '../utils/api-config';
+import { deserializePlayingTrack } from '../tracks-api';
 
 export const getAllTracks = async (sessionId: string): Promise<Track[]> => {
   try {
@@ -153,7 +154,7 @@ let ongoingSetTrackToPlayRequest: OngoingSetTrackToPlayRequest | null = null;
 export const setTrackToPlay = async (
   sessionId: string,
   changeSessionPlayingTracksRequest: ChangeSessionPlayingTracksRequest
-): Promise<SessionPlayingTracks | AbortedRequestError> => {
+): Promise<SessionPlayingTracksResponse | AbortedRequestError> => {
   // Abort previous request if any
   if (ongoingSetTrackToPlayRequest) {
     ongoingSetTrackToPlayRequest.abortController.abort();
@@ -172,33 +173,17 @@ export const setTrackToPlay = async (
       credentials: 'include',
       signal: ongoingSetTrackToPlayRequest.abortController.signal,
     });
-    const rawSerialized = response as SessionPlayingTracks;
+    const rawSerialized = response as SessionPlayingTracksResponse;
     ongoingSetTrackToPlayRequest = null;
 
     return {
       sessionId: rawSerialized.sessionId,
-      currentTrack: !rawSerialized.currentTrack
-        ? null
-        : new PlayingTrack(
-            rawSerialized.currentTrack.id,
-            rawSerialized.currentTrack.name,
-            rawSerialized.currentTrack.url,
-            rawSerialized.currentTrack.duration,
-            rawSerialized.currentTrack.isPaused,
-            rawSerialized.currentTrack.playTimestamp,
-            rawSerialized.currentTrack.trackStartTime
-          ),
+      currentTrack: !rawSerialized.currentTrack ? null : deserializePlayingTrack(rawSerialized.currentTrack),
       shortEffectTrack: !rawSerialized.shortEffectTrack
         ? null
-        : new PlayingTrack(
-            rawSerialized.shortEffectTrack.id,
-            rawSerialized.shortEffectTrack.name,
-            rawSerialized.shortEffectTrack.url,
-            rawSerialized.shortEffectTrack.duration,
-            rawSerialized.shortEffectTrack.isPaused,
-            rawSerialized.shortEffectTrack.playTimestamp,
-            rawSerialized.shortEffectTrack.trackStartTime
-          ),
+        : deserializePlayingTrack(rawSerialized.shortEffectTrack),
+      revision: rawSerialized.revision ?? 0,
+      currentPlayTimeMs: rawSerialized.currentPlayTimeMs ?? null,
     };
   } catch (error) {
     if ((error as DOMException).name === 'AbortError') {

--- a/apps/rpg-maestro-ui/src/app/maestro-ui/maestro-audio-player/maestro-audio-player.tsx
+++ b/apps/rpg-maestro-ui/src/app/maestro-ui/maestro-audio-player/maestro-audio-player.tsx
@@ -1,4 +1,4 @@
-import { PlayingTrack, SessionPlayingTracks, TrackToPlay } from '@rpg-maestro/rpg-maestro-api-contract';
+import { PlayingTrack, SessionPlayingTracksResponse, TrackToPlay } from '@rpg-maestro/rpg-maestro-api-contract';
 import AudioPlayer from 'react-h5-audio-player';
 import H5AudioPlayer from 'react-h5-audio-player';
 import React, { forwardRef, Ref, useCallback, useEffect, useImperativeHandle, useRef, useState } from 'react';
@@ -8,14 +8,14 @@ import './maestro-audio-player.css';
 import { AbortedRequestError } from '../maestro-api';
 
 export interface MaestroAudioPlayerRef {
-  dispatchTrackWasManuallyChanged: (newTracks: SessionPlayingTracks) => void;
+  dispatchTrackWasManuallyChanged: (newTracks: SessionPlayingTracksResponse) => void;
   togglePlayPause: () => Promise<void>;
   currentTrack: PlayingTrack | null;
 }
 
 export interface MaestroAudioPlayerProps {
   sessionId: string;
-  onCurrentTrackEdit: (editedCurrentTrack: TrackToPlay) => Promise<SessionPlayingTracks | AbortedRequestError>;
+  onCurrentTrackEdit: (editedCurrentTrack: TrackToPlay) => Promise<SessionPlayingTracksResponse | AbortedRequestError>;
 }
 
 const SYNC_TRACK_INTERVAL_MS = 5000;
@@ -27,8 +27,8 @@ export const MaestroAudioPlayer = forwardRef((props: MaestroAudioPlayerProps, re
   const isInUIResync = useRef(false);
   const audioPlayer = useRef<H5AudioPlayer>();
 
-  const dispatchTrackWasManuallyChanged = (newTracks: SessionPlayingTracks) => {
-    resyncCurrentTrackOnUi(newTracks.currentTrack);
+  const dispatchTrackWasManuallyChanged = (newTracks: SessionPlayingTracksResponse) => {
+    resyncCurrentTrackOnUi(newTracks.currentTrack, newTracks.currentPlayTimeMs);
   };
 
   if (audioPlayer.current?.progressBar.current) {
@@ -41,7 +41,7 @@ export const MaestroAudioPlayer = forwardRef((props: MaestroAudioPlayerProps, re
   }
 
   const resyncCurrentTrackOnUi = useCallback(
-    async (trackFromServer: PlayingTrack | null) => {
+    async (trackFromServer: PlayingTrack | null, playTimeMsFromServer: number | null) => {
       if (currentTrackEditRequested === null && !isInUIResync.current) {
         try {
           isInUIResync.current = true;
@@ -57,7 +57,8 @@ export const MaestroAudioPlayer = forwardRef((props: MaestroAudioPlayerProps, re
                 audioPlayer.current.audio.current.src = trackFromServer.url;
               }
               audioPlayer.current.audio.current.title = trackFromServer.name;
-              const currentPlayTime = trackFromServer.getCurrentPlayTime();
+              // Server-resolved: see the note on SyncResult.currentPlayTimeMs. Never recompute it here.
+              const currentPlayTime = playTimeMsFromServer;
               if (currentPlayTime) {
                 audioPlayer.current.audio.current.currentTime = currentPlayTime / 1000;
               }
@@ -99,7 +100,7 @@ export const MaestroAudioPlayer = forwardRef((props: MaestroAudioPlayerProps, re
     const requestFunc = () =>
       onCurrentTrackEdit(editedCurrentTrack).then((newTrack) => {
         if (newTrack !== 'AbortedRequestError') {
-          return resyncCurrentTrackOnUi(newTrack.currentTrack);
+          return resyncCurrentTrackOnUi(newTrack.currentTrack, newTrack.currentPlayTimeMs);
         }
       });
     try {
@@ -134,7 +135,7 @@ export const MaestroAudioPlayer = forwardRef((props: MaestroAudioPlayerProps, re
         }
         missingSessionAlreadyReported.current = false;
         if (syncResult !== 'AbortedRequestError') {
-          return resyncCurrentTrackOnUi(syncResult.currentTrack);
+          return resyncCurrentTrackOnUi(syncResult.currentTrack, syncResult.currentPlayTimeMs);
         }
         return Promise.resolve();
       });
@@ -167,7 +168,12 @@ export const MaestroAudioPlayer = forwardRef((props: MaestroAudioPlayerProps, re
       if (currentTrack.isPaused !== newPausedStatus) {
         // trying to handle load edge cases
         console.info(`changePlayingStatus newPausedStatus: ${newPausedStatus}`);
-        const stoppedTime = currentTrack.getCurrentPlayTime();
+        // The maestro's own audio element is the truth for where playback actually is — both when pausing
+        // (live position) and when resuming (where it was left). Deriving it from playTimestamp instead
+        // would drag this browser's clock offset into the startTime we then send to the server.
+        const stoppedTime = audioPlayer.current?.audio?.current
+          ? audioPlayer.current.audio.current.currentTime * 1000
+          : currentTrack.trackStartTime;
         currentTrack.trackStartTime = stoppedTime;
         currentTrack.isPaused = newPausedStatus;
         await requestCurrentTrackEdit({

--- a/apps/rpg-maestro-ui/src/app/maestro-ui/maestro-soundboard.tsx
+++ b/apps/rpg-maestro-ui/src/app/maestro-ui/maestro-soundboard.tsx
@@ -1,6 +1,6 @@
 import { filter, TrackFilters, TracksTable } from './tracks-table/tracks-table';
 import React, { useEffect, useMemo, useRef, useState } from 'react';
-import { SessionPlayingTracks, Tag, Track, TrackToPlay, User } from '@rpg-maestro/rpg-maestro-api-contract';
+import { SessionPlayingTracksResponse, Tag, Track, TrackToPlay, User } from '@rpg-maestro/rpg-maestro-api-contract';
 import { AbortedRequestError, getAllTracks, getSoundboardTracks, setTrackToPlay } from './maestro-api';
 import { ToastContainer } from 'react-toastify';
 import SearchSpecificTrack from './tracks-table/SearchSpecificTrack';
@@ -43,7 +43,7 @@ function MaestroSoundboardComponent() {
   }
   const maestroAudioPlayerChildRef = useRef<MaestroAudioPlayerRef>(null);
   const effectAudioRef = useRef<HTMLAudioElement>(null);
-  const dispatchTrackWasManuallyChanged = (newTracks: SessionPlayingTracks): void => {
+  const dispatchTrackWasManuallyChanged = (newTracks: SessionPlayingTracksResponse): void => {
     maestroAudioPlayerChildRef?.current?.dispatchTrackWasManuallyChanged(newTracks);
   };
   const currentPlayingTrack = maestroAudioPlayerChildRef?.current?.currentTrack ?? null;
@@ -119,7 +119,7 @@ function MaestroSoundboardComponent() {
   };
   const requestEditTrackToPlay = async (
     trackToPlay: TrackToPlay
-  ): Promise<SessionPlayingTracks | AbortedRequestError> => {
+  ): Promise<SessionPlayingTracksResponse | AbortedRequestError> => {
     return await setTrackToPlay(sessionId, { currentTrack: trackToPlay });
   };
 

--- a/apps/rpg-maestro-ui/src/app/players-ui/players-ui.tsx
+++ b/apps/rpg-maestro-ui/src/app/players-ui/players-ui.tsx
@@ -86,7 +86,10 @@ export function PlayersUi() {
             audioPlayer.current.audio.current.src = newerServerTrack.url;
           }
           audioPlayer.current.audio.current.title = newerServerTrack.name;
-          const currentPlayTime = newerServerTrack.getCurrentPlayTime();
+          // The server resolved this against its own clock. Computing it here from the browser's
+          // Date.now() would be off by this listener's clock offset, and a listener more than
+          // MAX_ACCEPTABLE_DESYNC_MS out would then reseek on every tick, forever.
+          const currentPlayTime = syncResult.currentPlayTimeMs ?? 0;
           audioPlayer.current.audio.current.currentTime = currentPlayTime / 1000;
           if (newerServerTrack.isPaused) {
             audioPlayer.current.audio.current.pause();

--- a/apps/rpg-maestro-ui/src/app/track-sync/track-sync.spec.ts
+++ b/apps/rpg-maestro-ui/src/app/track-sync/track-sync.spec.ts
@@ -13,149 +13,65 @@ beforeAll(() => {
 });
 describe('track-sync tests', () => {
   describe('isCurrentTrackTooMuchDesynchronizedFromServer', () => {
-    const serverTrackRunningFor15Seconds = new PlayingTrack(
-      '1',
-      '1',
-      'url',
-      120000,
-      false,
-      1730000000000,
-      0
-    );
+    // The server resolves its own playhead and sends it; this function only ever compares two numbers, so
+    // it no longer depends on any clock — that is the whole point of the change.
+    const serverPlayTimeMs = 15000;
     it('true for more than 5 seconds', () => {
-      const currentTrack = 21000;
-      expect(
-        isCurrentTrackTooMuchDesynchronizedFromServer(
-          currentTrack,
-          serverTrackRunningFor15Seconds
-        )
-      ).toBeTruthy();
+      expect(isCurrentTrackTooMuchDesynchronizedFromServer(21000, serverPlayTimeMs)).toBeTruthy();
     });
     it('false for 2 seconds advance', () => {
-      const currentTrack = 16999;
-      expect(
-        isCurrentTrackTooMuchDesynchronizedFromServer(
-          currentTrack,
-          serverTrackRunningFor15Seconds
-        )
-      ).toBeFalsy();
+      expect(isCurrentTrackTooMuchDesynchronizedFromServer(16999, serverPlayTimeMs)).toBeFalsy();
     });
     it('false for 2 seconds delay', () => {
-      const currentTrack = 14001;
-      expect(
-        isCurrentTrackTooMuchDesynchronizedFromServer(
-          currentTrack,
-          serverTrackRunningFor15Seconds
-        )
-      ).toBeFalsy();
+      expect(isCurrentTrackTooMuchDesynchronizedFromServer(14001, serverPlayTimeMs)).toBeFalsy();
+    });
+    it('false when the server reports no playhead, so nothing gets reseeked blindly', () => {
+      expect(isCurrentTrackTooMuchDesynchronizedFromServer(21000, null)).toBeFalsy();
+    });
+    it('true at 0, which must not be mistaken for "no playhead"', () => {
+      expect(isCurrentTrackTooMuchDesynchronizedFromServer(21000, 0)).toBeTruthy();
     });
   });
   describe('isCurrentTrackOutOfDate', () => {
+    const REVISION = 4;
     it('perfectly in sync', () => {
-      const serverTrack = new PlayingTrack(
-        '1',
-        '1',
-        'url',
-        120000,
-        false,
-        1730000000000,
-        0
-      );
-      const currentTrack = new PlayingTrack(
-        '1',
-        '1',
-        'url',
-        120000,
-        false,
-        1730000000000,
-        0
-      );
+      const serverTrack = new PlayingTrack('1', '1', 'url', 120000, false, 1730000000000, 0, REVISION);
+      const currentTrack = new PlayingTrack('1', '1', 'url', 120000, false, 1730000000000, 0, REVISION);
       expect(isCurrentTrackOutOfDate(currentTrack, serverTrack)).toBeFalsy();
     });
     it('server just paused', () => {
-      const serverTrack = new PlayingTrack(
-        '1',
-        '1',
-        'url',
-        120000,
-        true,
-        1730000000000,
-        0
-      );
-      const currentTrack = new PlayingTrack(
-        '1',
-        '1',
-        'url',
-        120000,
-        false,
-        1730000000000,
-        0
-      );
+      const serverTrack = new PlayingTrack('1', '1', 'url', 120000, true, 1730000000000, 0, REVISION + 1);
+      const currentTrack = new PlayingTrack('1', '1', 'url', 120000, false, 1730000000000, 0, REVISION);
       expect(isCurrentTrackOutOfDate(currentTrack, serverTrack)).toBeTruthy();
     });
     it('server just started', () => {
-      const serverTrack = new PlayingTrack(
-        '1',
-        '1',
-        'url',
-        120000,
-        false,
-        1730000000000,
-        0
-      );
-      const currentTrack = new PlayingTrack(
-        '1',
-        '1',
-        'url',
-        120000,
-        true,
-        1730000000000,
-        0
-      );
+      const serverTrack = new PlayingTrack('1', '1', 'url', 120000, false, 1730000000000, 0, REVISION + 1);
+      const currentTrack = new PlayingTrack('1', '1', 'url', 120000, true, 1730000000000, 0, REVISION);
       expect(isCurrentTrackOutOfDate(currentTrack, serverTrack)).toBeTruthy();
     });
     it('server just updated current play time', () => {
-      const justUpdatedPlayTimestamp = 1730000000001;
-      const serverTrack = new PlayingTrack(
-        '1',
-        '1',
-        'url',
-        120000,
-        true,
-        justUpdatedPlayTimestamp,
-        0
-      );
-      const currentTrack = new PlayingTrack(
-        '1',
-        '1',
-        'url',
-        120000,
-        true,
-        1730000000000,
-        0
-      );
+      const serverTrack = new PlayingTrack('1', '1', 'url', 120000, true, 1730000000001, 0, REVISION + 1);
+      const currentTrack = new PlayingTrack('1', '1', 'url', 120000, true, 1730000000000, 0, REVISION);
       expect(isCurrentTrackOutOfDate(currentTrack, serverTrack)).toBeTruthy();
     });
     it('server changed track', () => {
-      const serverTrack = new PlayingTrack(
-        'new-track-id',
-        '1',
-        'url',
-        120000,
-        true,
-        1730000000000,
-        0
-      );
-      const currentTrack = new PlayingTrack(
-        '1',
-        '1',
-        'url',
-        120000,
-        true,
-        1730000000000,
-        0
-      );
+      const serverTrack = new PlayingTrack('new-track-id', '1', 'url', 120000, true, 1730000000000, 0, REVISION + 1);
+      const currentTrack = new PlayingTrack('1', '1', 'url', 120000, true, 1730000000000, 0, REVISION);
       expect(isCurrentTrackOutOfDate(currentTrack, serverTrack)).toBeTruthy();
+    });
+    // The regression this whole change is about: two backend instances with skewed clocks can write a
+    // playTimestamp that moves backwards. Detection must not care.
+    it('server rewrote the track with an earlier playTimestamp than the browser holds', () => {
+      const serverTrack = new PlayingTrack('1', '1', 'url', 120000, false, 1730000000000, 0, REVISION + 1);
+      const currentTrack = new PlayingTrack('1', '1', 'url', 120000, false, 1730000009999, 0, REVISION);
+      expect(isCurrentTrackOutOfDate(currentTrack, serverTrack)).toBeTruthy();
+    });
+    // Mirror case: an unchanged track whose stored playTimestamp differs must not trigger an endless
+    // reseek. Under the old playTimestamp comparison this returned true on every single tick.
+    it('same revision is in sync even if playTimestamp differs', () => {
+      const serverTrack = new PlayingTrack('1', '1', 'url', 120000, false, 1730000000000, 0, REVISION);
+      const currentTrack = new PlayingTrack('1', '1', 'url', 120000, false, 1730000009999, 0, REVISION);
+      expect(isCurrentTrackOutOfDate(currentTrack, serverTrack)).toBeFalsy();
     });
   });
 });

--- a/apps/rpg-maestro-ui/src/app/track-sync/track-sync.ts
+++ b/apps/rpg-maestro-ui/src/app/track-sync/track-sync.ts
@@ -1,16 +1,26 @@
 import { getSessionPlayingTracks } from '../tracks-api';
-import { PlayingTrack, SessionPlayingTracks } from '@rpg-maestro/rpg-maestro-api-contract';
+import { PlayingTrack, SessionPlayingTracksResponse } from '@rpg-maestro/rpg-maestro-api-contract';
 import { AbortedRequestError, SessionNotFoundError } from '../maestro-ui/maestro-api';
+
+export const MAX_ACCEPTABLE_DESYNC_MS = 5000;
 
 export interface SyncResult {
   currentTrack: PlayingTrack | null;
+  /**
+   * Where to seek `currentTrack`, as resolved by the server. Only meaningful when `currentTrack` is set —
+   * null means there is nothing to seek.
+   *
+   * Callers must use this rather than `currentTrack.getCurrentPlayTime()`: in a browser that method would
+   * subtract a server-written timestamp from the local `Date.now()` and be wrong by the whole clock offset.
+   */
+  currentPlayTimeMs: number | null;
   shortEffectTrack: PlayingTrack | null;
 }
 
 /**
  *
  * @param sessionId
- * @param currentTrackPlayTime the requested play time of the track
+ * @param currentTrackPlayTime the play time of the track as it currently stands in the browser, in seconds
  * @param currentTrack the current track in the browser
  * @param localShortEffectTrack the current short effect track in the browser
  */
@@ -28,13 +38,17 @@ export const resyncIfNeeded = async (
   const newCurrentTrack = resolveCurrentTrackSync(currentTrackPlayTime, currentTrack, serverState);
   const newShortEffect = resolveShortEffectSync(localShortEffectTrack, serverState.shortEffectTrack);
 
-  return { currentTrack: newCurrentTrack, shortEffectTrack: newShortEffect };
+  return {
+    currentTrack: newCurrentTrack,
+    currentPlayTimeMs: serverState.currentPlayTimeMs,
+    shortEffectTrack: newShortEffect,
+  };
 };
 
 function resolveCurrentTrackSync(
   currentTrackPlayTime: number | null,
   currentTrack: PlayingTrack | null,
-  serverState: SessionPlayingTracks,
+  serverState: SessionPlayingTracksResponse,
 ): PlayingTrack | null {
   const serverTrack = serverState.currentTrack;
   if (!serverTrack) {
@@ -45,7 +59,7 @@ function resolveCurrentTrackSync(
     currentTrackPlayTime === undefined ||
     !currentTrack ||
     isCurrentTrackOutOfDate(currentTrack, serverTrack) ||
-    isCurrentTrackTooMuchDesynchronizedFromServer(currentTrackPlayTime * 1000, serverTrack)
+    isCurrentTrackTooMuchDesynchronizedFromServer(currentTrackPlayTime * 1000, serverState.currentPlayTimeMs)
   ) {
     return serverTrack;
   }
@@ -59,30 +73,41 @@ function resolveShortEffectSync(
   if (!serverEffectTrack) {
     return null;
   }
-  if (!localEffectTrack || localEffectTrack.playTimestamp !== serverEffectTrack.playTimestamp) {
+  if (!localEffectTrack || localEffectTrack.revision !== serverEffectTrack.revision) {
     return serverEffectTrack;
   }
   return null;
 }
 
+/**
+ * @param currentTrackPlayTime the browser's playhead, in ms
+ * @param serverPlayTimeMs the server's playhead, in ms, already resolved against the server's own clock
+ */
 export const isCurrentTrackTooMuchDesynchronizedFromServer = (
   currentTrackPlayTime: number,
-  serverTrack: PlayingTrack
+  serverPlayTimeMs: number | null
 ): boolean => {
-  const serverPlayTime = serverTrack.getCurrentPlayTime();
-  if (!serverPlayTime && serverPlayTime !== 0) {
+  if (serverPlayTimeMs === null || serverPlayTimeMs === undefined) {
     return false;
   }
-  const desyncTime = Math.abs(currentTrackPlayTime - serverPlayTime);
-  if (desyncTime > 5000) {
+  const desyncTime = Math.abs(currentTrackPlayTime - serverPlayTimeMs);
+  if (desyncTime > MAX_ACCEPTABLE_DESYNC_MS) {
     console.warn(
-      `CurrentTrackTooMuchDesynchronizedFromServer by ${desyncTime}ms, current: ${currentTrackPlayTime} vs server: ${serverPlayTime}`
+      `CurrentTrackTooMuchDesynchronizedFromServer by ${desyncTime}ms, current: ${currentTrackPlayTime} vs server: ${serverPlayTimeMs}`
     );
     return true;
   } else {
     return false;
   }
 };
+
+/**
+ * Whether the server changed the current track since the browser last took a copy.
+ *
+ * Decided on `revision`, a counter the server bumps per write. It used to be decided on `playTimestamp`,
+ * a wall-clock reading, which cannot order two writes made by two backend instances with skewed clocks.
+ * The id and paused checks stay as a safety net for a server that failed to bump.
+ */
 export const isCurrentTrackOutOfDate = (currentTrack: PlayingTrack, serverTrack: PlayingTrack): boolean => {
   if (currentTrack.id !== serverTrack.id) {
     console.info('CurrentTrackOutOfDate: track have changed');
@@ -90,8 +115,8 @@ export const isCurrentTrackOutOfDate = (currentTrack: PlayingTrack, serverTrack:
   } else if (currentTrack.isPaused !== serverTrack.isPaused) {
     console.info('CurrentTrackOutOfDate: track paused status have changed');
     return true;
-  } else if (currentTrack.playTimestamp !== serverTrack.playTimestamp) {
-    console.info('CurrentTrackOutOfDate: track playTimestamp have changed');
+  } else if (currentTrack.revision !== serverTrack.revision) {
+    console.info('CurrentTrackOutOfDate: track revision have changed');
     return true;
   }
   return false;

--- a/apps/rpg-maestro-ui/src/app/tracks-api.ts
+++ b/apps/rpg-maestro-ui/src/app/tracks-api.ts
@@ -1,5 +1,5 @@
 import { displayError } from './error-utils';
-import { PlayingTrack, SessionPlayingTracks } from '@rpg-maestro/rpg-maestro-api-contract';
+import { rehydratePlayingTrack, SessionPlayingTracksResponse } from '@rpg-maestro/rpg-maestro-api-contract';
 import { AbortedRequestError, SessionNotFoundError } from './maestro-ui/maestro-api';
 
 const rpgmaestroapiurl = import.meta.env.VITE_RPG_MAESTRO_API_URL;
@@ -10,23 +10,13 @@ interface OngoingRequest {
   startTimeMs: number;
 }
 
-function deserializePlayingTrack(track: PlayingTrack): PlayingTrack {
-  return new PlayingTrack(
-    track.id,
-    track.name,
-    track.url,
-    track.duration,
-    track.isPaused,
-    track.playTimestamp,
-    track.trackStartTime
-  );
-}
+export const deserializePlayingTrack = rehydratePlayingTrack;
 
 let ongoingRequest: OngoingRequest | null = null;
 export const getSessionPlayingTracks = async (
   sessionId: string,
   options?: { manuallyRequested?: boolean }
-): Promise<SessionPlayingTracks | AbortedRequestError | SessionNotFoundError> => {
+): Promise<SessionPlayingTracksResponse | AbortedRequestError | SessionNotFoundError> => {
   // Abort previous request if any
   if (ongoingRequest) {
     if (options?.manuallyRequested) {
@@ -47,12 +37,14 @@ export const getSessionPlayingTracks = async (
       signal: ongoingRequest.abortController.signal,
     });
     if (response.ok) {
-      const res = (await response.json()) as SessionPlayingTracks;
+      const res = (await response.json()) as SessionPlayingTracksResponse;
       ongoingRequest = null;
       return {
         sessionId: res.sessionId,
         currentTrack: res.currentTrack ? deserializePlayingTrack(res.currentTrack) : null,
         shortEffectTrack: res.shortEffectTrack ? deserializePlayingTrack(res.shortEffectTrack) : null,
+        revision: res.revision ?? 0,
+        currentPlayTimeMs: res.currentPlayTimeMs ?? null,
       };
     } else if (response.status === 404) {
       // Expected outcome for a mistyped or stale session link, not a transport failure: report it as
@@ -72,6 +64,6 @@ export const getSessionPlayingTracks = async (
     }
     console.error(error);
     displayError(`Fetch current/tracks error: ${error}`);
-    return { sessionId, currentTrack: null, shortEffectTrack: null };
+    return { sessionId, currentTrack: null, shortEffectTrack: null, revision: 0, currentPlayTimeMs: null };
   }
 };

--- a/apps/rpg-maestro/src/app/AuthenticatedMaestroController.ts
+++ b/apps/rpg-maestro/src/app/AuthenticatedMaestroController.ts
@@ -20,7 +20,8 @@ import { ManageCurrentlyPlayingTracks } from './maestro-api/ManageCurrentlyPlayi
 import {
   ChangeSessionPlayingTracksRequest,
   CreateSession,
-  SessionPlayingTracks,
+  SessionPlayingTracksResponse,
+  toSessionPlayingTracksResponse,
   Track,
   TrackCreation,
   TrackCreationFromYoutubeDto,
@@ -153,9 +154,13 @@ export class AuthenticatedMaestroController {
     @Request() req: { user: AuthenticatedUser },
     @Param('sessionId') sessionId: string,
     @Body() changeSessionPlayingTracks: ChangeSessionPlayingTracksRequest
-  ): Promise<SessionPlayingTracks> {
+  ): Promise<SessionPlayingTracksResponse> {
     await this.checkAccessOnSession(req.user, sessionId);
-    return await this.manageCurrentlyPlayingTracks.changeSessionPlayingTracks(sessionId, changeSessionPlayingTracks);
+    // The maestro UI seeks straight to the playhead in this response, so it has to be resolved here too,
+    // not just on the players' GET.
+    return toSessionPlayingTracksResponse(
+      await this.manageCurrentlyPlayingTracks.changeSessionPlayingTracks(sessionId, changeSessionPlayingTracks)
+    );
   }
 
   @Post('/maestro/sessions/:sessionId/tracks/from-collection/:collectionId')
@@ -175,13 +180,13 @@ export class AuthenticatedMaestroController {
   async createNewSession(
     @Request() req: { user: AuthenticatedUser },
     @Body() createSession: CreateSession
-  ): Promise<SessionPlayingTracks> {
-    return await this.onboardingService.createSession(createSession, req.user.id);
+  ): Promise<SessionPlayingTracksResponse> {
+    return toSessionPlayingTracksResponse(await this.onboardingService.createSession(createSession, req.user.id));
   }
 
   @Post('/maestro/onboard')
-  async createSession(@Request() req: { user: AuthenticatedUser }): Promise<SessionPlayingTracks> {
-    return await this.onboardingService.createNewUserWithSession(req.user.id);
+  async createSession(@Request() req: { user: AuthenticatedUser }): Promise<SessionPlayingTracksResponse> {
+    return toSessionPlayingTracksResponse(await this.onboardingService.createNewUserWithSession(req.user.id));
   }
 
   async checkAccessOnSession(reqUser: AuthenticatedUser, sessionId: string) {

--- a/apps/rpg-maestro/src/app/PlayersController.ts
+++ b/apps/rpg-maestro/src/app/PlayersController.ts
@@ -1,5 +1,9 @@
 import { Controller, Get, HttpException, HttpStatus, Inject, Param } from '@nestjs/common';
-import { SessionPlayingTracks, Track } from '@rpg-maestro/rpg-maestro-api-contract';
+import {
+  SessionPlayingTracksResponse,
+  Track,
+  toSessionPlayingTracksResponse,
+} from '@rpg-maestro/rpg-maestro-api-contract';
 import { SessionsService } from './sessions/sessions.service';
 import { TrackService } from './maestro-api/TrackService';
 
@@ -18,11 +22,13 @@ export class PlayersController {
   }
 
   @Get('/sessions/:id/playing-tracks')
-  async getSessionTracks(@Param('id') sessionId: string): Promise<SessionPlayingTracks> {
+  async getSessionTracks(@Param('id') sessionId: string): Promise<SessionPlayingTracksResponse> {
     const dbValue = await this.sessionsService.getSessionPlayingTracks(sessionId);
     if (!dbValue) {
       throw new HttpException(`Session '${sessionId}' not found`, HttpStatus.NOT_FOUND);
     }
-    return dbValue;
+    // Resolved here, against the server clock, and never stored: players must not compute the playhead from
+    // their own Date.now(), which is off by their whole clock offset from ours.
+    return toSessionPlayingTracksResponse(dbValue);
   }
 }

--- a/apps/rpg-maestro/src/app/infrastructure/persistence/firestore/FirestoreTracksDatabase.ts
+++ b/apps/rpg-maestro/src/app/infrastructure/persistence/firestore/FirestoreTracksDatabase.ts
@@ -21,6 +21,7 @@ export class FirestoreTracksDatabase implements TracksDatabase {
       id: sessionId,
       currentTrack: null,
       shortEffectTrack: null,
+      revision: 0,
     };
     await this.db.collection(RPG_MAESTRO_SESSIONS_DB).doc(sessionId).set(newSession);
     return await Promise.resolve();
@@ -52,10 +53,13 @@ export class FirestoreTracksDatabase implements TracksDatabase {
 
   async upsertCurrentTrack(sessionId: string, playingTrack: PlayingTrack): Promise<SessionPlayingTracks> {
     const existing = await this.getSession(sessionId);
+    const revision = (existing?.revision ?? 0) + 1;
     const sessionEntity: SessionPlayingTrackEntity = {
       id: sessionId,
-      currentTrack: playingTrackToEntity(playingTrack),
+      currentTrack: playingTrackToEntity(playingTrack, revision),
+      // Untouched slot keeps its own revision, so a music change does not make a live effect look new.
       shortEffectTrack: existing?.shortEffectTrack ? playingTrackToEntity(existing.shortEffectTrack) : null,
+      revision,
     };
     await this.db
       .collection(RPG_MAESTRO_SESSIONS_DB)
@@ -66,10 +70,12 @@ export class FirestoreTracksDatabase implements TracksDatabase {
 
   async upsertShortEffectTrack(sessionId: string, playingTrack: PlayingTrack): Promise<SessionPlayingTracks> {
     const existing = await this.getSession(sessionId);
+    const revision = (existing?.revision ?? 0) + 1;
     const sessionEntity: SessionPlayingTrackEntity = {
       id: sessionId,
       currentTrack: existing?.currentTrack ? playingTrackToEntity(existing.currentTrack) : null,
-      shortEffectTrack: playingTrackToEntity(playingTrack),
+      shortEffectTrack: playingTrackToEntity(playingTrack, revision),
+      revision,
     };
     await this.db
       .collection(RPG_MAESTRO_SESSIONS_DB)
@@ -98,6 +104,8 @@ interface SessionPlayingTrackEntity {
   id: string;
   currentTrack: PlayingTrackEntity | null;
   shortEffectTrack: PlayingTrackEntity | null;
+  /** Optional on read only: documents written before revisions existed do not carry it. */
+  revision?: number;
 }
 
 interface PlayingTrackEntity {
@@ -109,9 +117,15 @@ interface PlayingTrackEntity {
   isPaused: boolean;
   playTimestamp: number;
   trackStartTime: number;
+  revision?: number;
 }
 
-function playingTrackToEntity(track: PlayingTrack): PlayingTrackEntity {
+/**
+ * `revision` is passed in rather than read off the track, because the caller builds the PlayingTrack before
+ * the store has decided which revision the write gets. Omit it to carry over whatever the track already had
+ * (used when rewriting the slot this write did not touch).
+ */
+function playingTrackToEntity(track: PlayingTrack, revision?: number): PlayingTrackEntity {
   return {
     id: track.id,
     name: track.name,
@@ -120,6 +134,7 @@ function playingTrackToEntity(track: PlayingTrack): PlayingTrackEntity {
     isPaused: track.isPaused,
     playTimestamp: track.playTimestamp,
     trackStartTime: track.trackStartTime,
+    revision: revision ?? track.revision ?? 0,
   };
 }
 
@@ -131,7 +146,10 @@ function entityToPlayingTrack(entity: PlayingTrackEntity): PlayingTrack {
     entity.duration,
     entity.isPaused,
     entity.playTimestamp,
-    entity.trackStartTime
+    entity.trackStartTime,
+    // Pre-revision documents read back as 0. The first write after this deploy bumps the session to 1, which
+    // every client sees as a change and resyncs once — a single harmless reseek, not a stuck state.
+    entity.revision ?? 0
   );
 }
 
@@ -140,5 +158,6 @@ function entityToSession(entity: SessionPlayingTrackEntity): SessionPlayingTrack
     sessionId: entity.id,
     currentTrack: entity.currentTrack ? entityToPlayingTrack(entity.currentTrack) : null,
     shortEffectTrack: entity.shortEffectTrack ? entityToPlayingTrack(entity.shortEffectTrack) : null,
+    revision: entity.revision ?? 0,
   };
 }

--- a/apps/rpg-maestro/src/app/infrastructure/persistence/in-memory/InMemoryTracksDatabase.spec.ts
+++ b/apps/rpg-maestro/src/app/infrastructure/persistence/in-memory/InMemoryTracksDatabase.spec.ts
@@ -1,0 +1,70 @@
+import { PlayingTrack } from '@rpg-maestro/rpg-maestro-api-contract';
+import { InMemoryTracksDatabase } from './InMemoryTracksDatabase';
+
+function aTrack(id: string): PlayingTrack {
+  return new PlayingTrack(id, id, `url-${id}`, 120000, false, 1730000000000, 0);
+}
+
+describe('InMemoryTracksDatabase revisions', () => {
+  it('starts a created session at revision 0', async () => {
+    const db = new InMemoryTracksDatabase();
+    await db.createSession('s1');
+
+    expect((await db.getSession('s1'))?.revision).toBe(0);
+  });
+
+  it('bumps the session revision on every write', async () => {
+    const db = new InMemoryTracksDatabase();
+    await db.createSession('s1');
+
+    expect((await db.upsertCurrentTrack('s1', aTrack('t1'))).revision).toBe(1);
+    expect((await db.upsertCurrentTrack('s1', aTrack('t2'))).revision).toBe(2);
+    expect((await db.upsertShortEffectTrack('s1', aTrack('fx1'))).revision).toBe(3);
+  });
+
+  it('stamps the new revision onto the track it wrote', async () => {
+    const db = new InMemoryTracksDatabase();
+    await db.createSession('s1');
+
+    const session = await db.upsertCurrentTrack('s1', aTrack('t1'));
+
+    expect(session.currentTrack?.revision).toBe(session.revision);
+  });
+
+  /**
+   * The reason revisions are per-track and not just per-session: players decide whether to reseek the music
+   * by comparing currentTrack.revision. If a sound effect bumped it, every effect would yank the music's
+   * playhead for every listener.
+   */
+  it('leaves the current track revision alone when only a short effect is played', async () => {
+    const db = new InMemoryTracksDatabase();
+    await db.createSession('s1');
+    const afterMusic = await db.upsertCurrentTrack('s1', aTrack('t1'));
+    const musicRevision = afterMusic.currentTrack?.revision;
+
+    const afterEffect = await db.upsertShortEffectTrack('s1', aTrack('fx1'));
+
+    expect(afterEffect.currentTrack?.revision).toBe(musicRevision);
+    expect(afterEffect.shortEffectTrack?.revision).toBe(afterEffect.revision);
+    expect(afterEffect.revision).not.toBe(musicRevision);
+  });
+
+  it('replaying the same effect changes its revision, so a repeat is not swallowed', async () => {
+    const db = new InMemoryTracksDatabase();
+    await db.createSession('s1');
+
+    const first = await db.upsertShortEffectTrack('s1', aTrack('fx1'));
+    const second = await db.upsertShortEffectTrack('s1', aTrack('fx1'));
+
+    expect(second.shortEffectTrack?.revision).not.toBe(first.shortEffectTrack?.revision);
+  });
+
+  it('upserting into a session that was never created still produces a usable revision', async () => {
+    const db = new InMemoryTracksDatabase();
+
+    const session = await db.upsertCurrentTrack('never-created', aTrack('t1'));
+
+    expect(session.revision).toBe(1);
+    expect(session.currentTrack?.revision).toBe(1);
+  });
+});

--- a/apps/rpg-maestro/src/app/infrastructure/persistence/in-memory/InMemoryTracksDatabase.ts
+++ b/apps/rpg-maestro/src/app/infrastructure/persistence/in-memory/InMemoryTracksDatabase.ts
@@ -6,7 +6,12 @@ export class InMemoryTracksDatabase implements TracksDatabase {
   sessionDatabase: { [name: SessionID]: SessionPlayingTracks } = {};
 
   createSession(sessionId: SessionID): Promise<void> {
-    this.sessionDatabase[sessionId] = { sessionId: sessionId, currentTrack: null, shortEffectTrack: null };
+    this.sessionDatabase[sessionId] = {
+      sessionId: sessionId,
+      currentTrack: null,
+      shortEffectTrack: null,
+      revision: 0,
+    };
     return Promise.resolve();
   }
 
@@ -19,6 +24,7 @@ export class InMemoryTracksDatabase implements TracksDatabase {
       sessionId: sessionId,
       currentTrack: this.sessionDatabase[sessionId]?.currentTrack,
       shortEffectTrack: this.sessionDatabase[sessionId]?.shortEffectTrack ?? null,
+      revision: this.sessionDatabase[sessionId].revision,
     });
   }
 
@@ -33,21 +39,41 @@ export class InMemoryTracksDatabase implements TracksDatabase {
   }
 
   upsertCurrentTrack(sessionId: string, playingTrack: PlayingTrack): Promise<SessionPlayingTracks> {
+    const revision = this.nextRevision(sessionId);
+    const stampedTrack = withRevision(playingTrack, revision);
     if (!this.sessionDatabase[sessionId]) {
-      this.sessionDatabase[sessionId] = { sessionId: sessionId, currentTrack: playingTrack, shortEffectTrack: null };
+      this.sessionDatabase[sessionId] = {
+        sessionId: sessionId,
+        currentTrack: stampedTrack,
+        shortEffectTrack: null,
+        revision,
+      };
     } else {
-      this.sessionDatabase[sessionId].currentTrack = playingTrack;
+      this.sessionDatabase[sessionId].currentTrack = stampedTrack;
+      this.sessionDatabase[sessionId].revision = revision;
     }
-    return Promise.resolve(this.sessionDatabase[sessionId]);
+    return Promise.resolve(snapshot(this.sessionDatabase[sessionId]));
   }
 
   upsertShortEffectTrack(sessionId: string, playingTrack: PlayingTrack): Promise<SessionPlayingTracks> {
+    const revision = this.nextRevision(sessionId);
+    const stampedTrack = withRevision(playingTrack, revision);
     if (!this.sessionDatabase[sessionId]) {
-      this.sessionDatabase[sessionId] = { sessionId: sessionId, currentTrack: null, shortEffectTrack: playingTrack };
+      this.sessionDatabase[sessionId] = {
+        sessionId: sessionId,
+        currentTrack: null,
+        shortEffectTrack: stampedTrack,
+        revision,
+      };
     } else {
-      this.sessionDatabase[sessionId].shortEffectTrack = playingTrack;
+      this.sessionDatabase[sessionId].shortEffectTrack = stampedTrack;
+      this.sessionDatabase[sessionId].revision = revision;
     }
-    return Promise.resolve(this.sessionDatabase[sessionId]);
+    return Promise.resolve(snapshot(this.sessionDatabase[sessionId]));
+  }
+
+  private nextRevision(sessionId: string): number {
+    return (this.sessionDatabase[sessionId]?.revision ?? 0) + 1;
   }
 
   getTrack(trackId: string): Promise<Track> {
@@ -63,3 +89,28 @@ export class InMemoryTracksDatabase implements TracksDatabase {
   }
 }
 
+/**
+ * Detach the returned session from the one this store keeps mutating. Without this the caller holds a live
+ * reference, and a later write silently rewrites a value they already read — which is not how the Firestore
+ * implementation behaves, so tests passing against one would not pass against the other.
+ */
+function snapshot(session: SessionPlayingTracks): SessionPlayingTracks {
+  return { ...session };
+}
+
+/**
+ * The caller builds the PlayingTrack before the store knows which revision it will get, so the revision is
+ * stamped on here rather than passed in. Returns a copy: callers keep their own reference to the argument.
+ */
+function withRevision(playingTrack: PlayingTrack, revision: number): PlayingTrack {
+  return new PlayingTrack(
+    playingTrack.id,
+    playingTrack.name,
+    playingTrack.url,
+    playingTrack.duration,
+    playingTrack.isPaused,
+    playingTrack.playTimestamp,
+    playingTrack.trackStartTime,
+    revision
+  );
+}

--- a/apps/rpg-maestro/src/app/sessions/sessions.cache.spec.ts
+++ b/apps/rpg-maestro/src/app/sessions/sessions.cache.spec.ts
@@ -1,0 +1,45 @@
+import { PlayingTrack, SessionPlayingTracks } from '@rpg-maestro/rpg-maestro-api-contract';
+import { SessionsCache } from './sessions.cache';
+
+/**
+ * Keyv serializes to JSON on every tier, including the in-process one used here, so a session put in as a
+ * tree of class instances comes back out as plain objects. Anything that then calls a method on one of its
+ * tracks — as the API does to resolve the playhead — dies with "getCurrentPlayTime is not a function".
+ */
+describe('SessionsCache', () => {
+  function aSession(sessionId: string): SessionPlayingTracks {
+    return {
+      sessionId,
+      currentTrack: new PlayingTrack('track-1', 'Track One', 'url', 120000, false, 1730000000000, 5000, 3),
+      shortEffectTrack: new PlayingTrack('fx-1', 'Door Slam', 'fx-url', 2000, false, 1730000000000, 0, 3),
+      revision: 3,
+    };
+  }
+
+  it('returns tracks that still have their methods after a cache round-trip', async () => {
+    const cache = new SessionsCache();
+    await cache.set(aSession('session-round-trip'));
+
+    const cached = await cache.get('session-round-trip');
+
+    expect(cached).toBeDefined();
+    expect(cached?.currentTrack?.getCurrentPlayTime(1730000010000)).toBe(15000);
+    expect(cached?.shortEffectTrack?.getCurrentPlayTime(1730000000000)).toBe(0);
+  });
+
+  it('preserves the revision through the round-trip, since sync detection depends on it', async () => {
+    const cache = new SessionsCache();
+    await cache.set(aSession('session-revision'));
+
+    const cached = await cache.get('session-revision');
+
+    expect(cached?.revision).toBe(3);
+    expect(cached?.currentTrack?.revision).toBe(3);
+  });
+
+  it('returns undefined for an unknown session rather than an empty shell', async () => {
+    const cache = new SessionsCache();
+
+    expect(await cache.get('never-stored')).toBeUndefined();
+  });
+});

--- a/apps/rpg-maestro/src/app/sessions/sessions.cache.ts
+++ b/apps/rpg-maestro/src/app/sessions/sessions.cache.ts
@@ -1,5 +1,5 @@
 import ms from 'ms';
-import { SessionPlayingTracks } from '@rpg-maestro/rpg-maestro-api-contract';
+import { rehydrateSessionPlayingTracks, SessionPlayingTracks } from '@rpg-maestro/rpg-maestro-api-contract';
 import { ResilientCache } from '../infrastructure/cache/resilient-cache';
 import { createCacheTiers } from '../infrastructure/cache/cache-tiers.factory';
 
@@ -11,7 +11,14 @@ export class SessionsCache {
   }
 
   async get(sessionId: string): Promise<SessionPlayingTracks | undefined> {
-    return await this.cache.get(sessionId);
+    const cached = await this.cache.get(sessionId);
+    if (!cached) {
+      return undefined;
+    }
+    // Keyv serializes to JSON on every tier, including the in-process one, so what comes back has the right
+    // fields but no prototype. Callers get a SessionPlayingTracks from this method and are entitled to call
+    // methods on its tracks, so the rehydration belongs here rather than in each of them.
+    return rehydrateSessionPlayingTracks(cached);
   }
 
   async set(session: SessionPlayingTracks): Promise<void> {

--- a/libs/rpg-maestro-api-contract/src/lib/PlayingTrack.spec.ts
+++ b/libs/rpg-maestro-api-contract/src/lib/PlayingTrack.spec.ts
@@ -19,7 +19,9 @@ describe("PlayingTrack getCurrentPlayTime()", () => {
     );
     expect(pausedTrack.getCurrentPlayTime()).toBe(10563);
   });
-  it("should raise error when the track is set to play in the future", () => {
+  // Used to throw. A caller whose clock trails the writer's hits this on every single tick, and the throw
+  // took down their whole sync loop rather than just this reading, so it now clamps to "not started yet".
+  it("should clamp to the track start time when the track is set to play in the future", () => {
     const playingTrack = new PlayingTrack(
       "id1",
       "name1",
@@ -27,9 +29,18 @@ describe("PlayingTrack getCurrentPlayTime()", () => {
       120000,
       false,
       Number.MAX_VALUE,
-      0
+      7000
     );
-    expect(() => playingTrack.getCurrentPlayTime()).toThrow('this.playTimestamp in the future are not handled');
+    expect(playingTrack.getCurrentPlayTime()).toBe(7000);
+  });
+  it("should resolve against the clock it is given rather than the local one", () => {
+    const trackStartedAt = 1730000000000;
+    const playingTrack = new PlayingTrack("id1", "name1", "url", 120000, false, trackStartedAt, 0);
+
+    // A browser 40s behind the server would compute 40s less than the server does. Passing the server's
+    // clock explicitly is what keeps every listener on the same playhead.
+    expect(playingTrack.getCurrentPlayTime(trackStartedAt + 15000)).toBe(15000);
+    expect(playingTrack.getCurrentPlayTime(trackStartedAt - 40000)).toBe(0);
   });
   it("should return the current time the track is playing when it was started from 0", () => {
     const playTimestamp15sAgo = NOW.getTime() - 15000;

--- a/libs/rpg-maestro-api-contract/src/lib/PlayingTrack.ts
+++ b/libs/rpg-maestro-api-contract/src/lib/PlayingTrack.ts
@@ -7,6 +7,13 @@ export class PlayingTrack {
   isPaused: boolean;
   playTimestamp: number;
   trackStartTime: number;
+  /**
+   * Monotonic counter, bumped by the server every time this slot of the session is written. It is what a
+   * client compares to decide "did the server change this track?". `playTimestamp` used to serve that
+   * purpose, but it is a wall-clock reading, so across several backend instances it is not guaranteed to
+   * move forward between two consecutive writes.
+   */
+  revision: number;
 
   constructor(
     id: string,
@@ -15,7 +22,8 @@ export class PlayingTrack {
     duration: number,
     isPaused: boolean,
     playTimestamp: number,
-    trackStartTime: number
+    trackStartTime: number,
+    revision = 0
   ) {
     this.id = id;
     this.name = name;
@@ -24,17 +32,46 @@ export class PlayingTrack {
     this.isPaused = isPaused;
     this.playTimestamp = playTimestamp;
     this.trackStartTime = trackStartTime;
+    this.revision = revision;
   }
 
-  getCurrentPlayTime(): number {
-    if (this.playTimestamp > Date.now()) {
-      throw new Error('this.playTimestamp in the future are not handled');
-    }
+  /**
+   * Where the playhead should be, in ms.
+   *
+   * `nowMs` must come from the same clock that produced `playTimestamp` — the server's. Browser callers
+   * must NOT let it default to their own `Date.now()`: the result would be wrong by the entire
+   * browser-to-server clock offset. The server computes this once and ships it to clients as
+   * `SessionPlayingTracksResponse.currentPlayTimeMs`.
+   */
+  getCurrentPlayTime(nowMs: number = Date.now()): number {
     if (this.isPaused) {
       return this.trackStartTime;
     }
-    const elapsedPlayTime = Date.now() - this.playTimestamp;
+    // A timestamp in the future means the caller's clock trails whichever clock wrote it. Clamping to
+    // "no time elapsed yet" is wrong by at most that skew; throwing (which this used to do) took down
+    // the caller's entire sync tick instead, and every tick after it.
+    const elapsedPlayTime = Math.max(0, nowMs - this.playTimestamp);
     const timeTheTrackWasPlayed = elapsedPlayTime + this.trackStartTime;
     return timeTheTrackWasPlayed % this.duration;
   }
+}
+
+/**
+ * Rebuild a real PlayingTrack from a plain object.
+ *
+ * Anything that has been through JSON — an HTTP response, or the Keyv-backed session cache, which
+ * serializes even for its in-process store — hands back an object with the right fields and none of the
+ * methods. Call this at every such boundary, or `getCurrentPlayTime` blows up with "is not a function".
+ */
+export function rehydratePlayingTrack(plain: PlayingTrack): PlayingTrack {
+  return new PlayingTrack(
+    plain.id,
+    plain.name,
+    plain.url,
+    plain.duration,
+    plain.isPaused,
+    plain.playTimestamp,
+    plain.trackStartTime,
+    plain.revision ?? 0
+  );
 }

--- a/libs/rpg-maestro-api-contract/src/lib/SessionPlayingTracks.ts
+++ b/libs/rpg-maestro-api-contract/src/lib/SessionPlayingTracks.ts
@@ -1,4 +1,4 @@
-import { PlayingTrack } from './PlayingTrack';
+import { PlayingTrack, rehydratePlayingTrack } from './PlayingTrack';
 import { IsString, IsOptional, IsArray } from 'class-validator';
 
 // TODO make this a real session, with create and update date
@@ -6,6 +6,51 @@ export interface SessionPlayingTracks {
   sessionId: SessionID;
   currentTrack: PlayingTrack | null;
   shortEffectTrack: PlayingTrack | null;
+  /**
+   * Monotonic counter bumped on every write to the session, whichever slot was written. Each write also
+   * stamps the new value onto the track it wrote, so `currentTrack.revision` changes only when the
+   * current track itself changed — playing a short effect does not make the music look stale.
+   *
+   * Doubles as the version for conditional writes (see the optimistic-concurrency issue) and as the SSE
+   * event id once the push channel lands.
+   */
+  revision: number;
+}
+
+/**
+ * What the API actually returns for a session: the stored state plus the playhead, resolved server-side.
+ *
+ * `currentPlayTimeMs` deliberately does NOT live on {@link SessionPlayingTracks}, because that shape is
+ * what gets persisted and cached — a playhead cached for a day would be a day stale. It is computed at
+ * the response boundary, per request, and only ever exists on the way out.
+ */
+export interface SessionPlayingTracksResponse extends SessionPlayingTracks {
+  /** Playhead of `currentTrack` in ms at the moment the server answered, or null if nothing is playing. */
+  currentPlayTimeMs: number | null;
+}
+
+/**
+ * Resolve the playhead against the server's own clock. Call this at the response boundary, never before
+ * caching or persisting.
+ */
+export function toSessionPlayingTracksResponse(
+  session: SessionPlayingTracks,
+  nowMs: number = Date.now()
+): SessionPlayingTracksResponse {
+  return {
+    ...session,
+    currentPlayTimeMs: session.currentTrack ? session.currentTrack.getCurrentPlayTime(nowMs) : null,
+  };
+}
+
+/** See {@link rehydratePlayingTrack} — same problem, at session granularity. */
+export function rehydrateSessionPlayingTracks(plain: SessionPlayingTracks): SessionPlayingTracks {
+  return {
+    sessionId: plain.sessionId,
+    currentTrack: plain.currentTrack ? rehydratePlayingTrack(plain.currentTrack) : null,
+    shortEffectTrack: plain.shortEffectTrack ? rehydratePlayingTrack(plain.shortEffectTrack) : null,
+    revision: plain.revision ?? 0,
+  };
 }
 
 export type SessionID = string;


### PR DESCRIPTION
First of the three PRs planned for #116. This one is a bug fix that happens to also unblock multi-instance; it needs no new infrastructure.

## The bug

`PlayingTrack.getCurrentPlayTime()` is a shared contract class that runs on **both** sides. `playTimestamp` is stamped with the *server's* `Date.now()` (`ManageCurrentlyPlayingTracks.ts`), and `tracks-api.ts` rehydrates the JSON into a real `PlayingTrack`, so the browser then called `getCurrentPlayTime()` — subtracting that stamp from its *own* `Date.now()`. Every listener seeked to a position wrong by its own clock offset from the backend.

This was live on a single instance. Two failure modes:

1. **Permanent reseek loop.** A client skewed more than `MAX_ACCEPTABLE_DESYNC_MS` (5s) tripped `isCurrentTrackTooMuchDesynchronizedFromServer` every tick, seeked to a wrong position, and was still skewed 1s later — because the offset being corrected for was inside the comparison itself. Audible stutter once per second, indefinitely.
2. **Sync loop death.** A client whose clock ran *behind* the server hit `playTimestamp > Date.now()`, which threw. The throw was unhandled inside `resyncOnUi`, so the promise rejected and sync stopped for that tick and every tick after.

Multi-instance skew adds a third: `playTimestamp` stops being monotonic across writes, and it was being compared for equality as a de-facto version.

## What changed

- **The server resolves the playhead** and returns it as `SessionPlayingTracksResponse.currentPlayTimeMs`. It is computed at the response boundary and deliberately *not* part of the persisted/cached shape — a playhead cached for a day would be a day stale.
- **`getCurrentPlayTime(nowMs)` takes its clock as a parameter** and clamps a future timestamp to "not started yet" rather than throwing.
- **Sessions and tracks carry a monotonic `revision`.** Change detection compares that instead of `playTimestamp`. Revisions are stamped **per track**, so playing a sound effect does not make the music look stale and yank every listener's playhead.
- **The maestro derives pause/resume position from its own audio element**, which is the actual truth for where its playback is, instead of from `playTimestamp`.

`revision` is also the version field that makes the optimistic-concurrency issue cheap to implement, and the SSE event id for PR 3.

## Two bugs found on the way

Both pre-existing, both now fixed and covered:

- **`SessionsCache` returned plain objects.** Keyv serializes to JSON on *every* tier including the in-process one, so cached tracks came back with the right fields and no prototype. Nothing noticed while the server only ever re-serialized them to JSON — this PR's mapper is the first server-side caller of a method on them, and it blew up with `getCurrentPlayTime is not a function`. Now rehydrated on read.
- **`InMemoryTracksDatabase` upserts returned the live stored session**, so a later write silently rewrote a value the caller had already read. The Firestore implementation returns a fresh object, so a test could pass against one and fail against the other. Caught by a new test.

## Migration

Firestore documents written before `revision` existed read back as `0`. The first write after deploy bumps the session to `1`, which clients see as one ordinary change and resync once. No backfill needed, no stuck state.

## Verification

- `nx run-many -t test --projects=rpg-maestro,rpg-maestro-ui,rpg-maestro-api-contract` → **137 passed** (62 / 68 / 7)
- `nx run-many -t lint` → 0 errors (3 pre-existing warnings untouched)
- Build green (runs as a lint dependency)
- `tsc --noEmit` on both apps: backend clean; UI back to its **2 pre-existing** errors (`theme.ts`, `FeaturesConfiguration.ts`), which are unrelated and were failing before this branch

New tests: revision semantics in `InMemoryTracksDatabase.spec.ts` (including the effect-must-not-bump-the-music case), cache round-trip in `sessions.cache.spec.ts`, clock-injection and future-timestamp clamping in `PlayingTrack.spec.ts`, and two regression cases in `track-sync.spec.ts` for a `playTimestamp` that moves backwards.

I also completed the 5 session fixtures in `admin-board.stories.tsx`. They were already failing to typecheck on `main` (missing `shortEffectTrack`); I filled them in so nobody mistakes the `revision` now in that error message for fallout from this PR.

## Still open

The 5s desync threshold is untouched here. It is loose for music — fine for ambience, wrong for a timed cue. Now that the clock offset is out of the comparison, tightening it is a safe follow-up; before this PR it would have made the reseek loop near-universal.

## Not in this PR

- PR 2 — `GET /time` and client-side offset estimation, needed before push because a pushed client has no poll to re-derive position from
- PR 3 — SSE endpoint, Redis pub/sub fanout, `EventSource` client with polling fallback
