### PR TITLE
feat(playback): server-authoritative clock + SSE push channel (closes #116)

### DIFF
--- a/apps/rpg-maestro-ui-e2e/src/maestro-audio-player.spec.ts
+++ b/apps/rpg-maestro-ui-e2e/src/maestro-audio-player.spec.ts
@@ -1,0 +1,93 @@
+import { expect, test } from '@playwright/test';
+import {
+  createTrackViaApi,
+  generateNewSession,
+  initUsersFixtureSpec,
+  RPG_MAESTRO_URL,
+  setTrackToPlayViaApi,
+  UserWithGeneratedSession,
+} from './fixtures';
+import { goToMaestroPage, simulateAuthenticatedInBrowser, waitForAppToBeReady } from './navigation';
+import { TestUsersFixture } from '@rpg-maestro/test-utils';
+
+/**
+ * The Maestro's own audio player, driven in a browser. Everything else exercises it only as a side
+ * effect of loading the soundboard, which leaves the part that matters — where the playhead lands, and
+ * whether pausing reaches the server — untested.
+ */
+let userFixture: TestUsersFixture;
+
+test.beforeAll(async ({ browser }) => {
+  const page = await browser.newPage();
+  await waitForAppToBeReady(page);
+  userFixture = await initUsersFixtureSpec();
+  await page.close();
+});
+
+test('the Maestro player picks up the playing track, at a sane playhead, and can pause it', async ({ page }) => {
+  const consoleErrors: string[] = [];
+  const pageErrors: string[] = [];
+  page.on('console', (message) => {
+    if (message.type() === 'error') {
+      consoleErrors.push(message.text());
+    }
+  });
+  page.on('pageerror', (error) => pageErrors.push(String(error)));
+
+  let user: UserWithGeneratedSession;
+  let trackName: string;
+
+  await test.step('prepare data: a session with a track playing', async () => {
+    user = await generateNewSession(userFixture.a_maestro_user);
+    const track = await createTrackViaApi(user, user.sessionId, {
+      url: `${RPG_MAESTRO_URL}/public/race1.ogg`,
+      name: 'maestro-audio-player-test',
+    });
+    trackName = track.name;
+    await setTrackToPlayViaApi(user, user.sessionId, track.id);
+  });
+
+  await simulateAuthenticatedInBrowser(page, user);
+  await goToMaestroPage(page, user.sessionId);
+
+  await test.step('the player shows the track the session is playing', async () => {
+    await expect(page.locator('.maestro-audio-player').getByText(trackName)).toBeVisible();
+  });
+
+  await test.step('the playhead sits near the start, not at a clock-skew-sized offset', async () => {
+    // The track was set to play seconds ago from position 0, so anything beyond a few seconds means the
+    // playhead was computed against the wrong clock.
+    await expect
+      .poll(() =>
+        page.evaluate(
+          () => (document.querySelector('.maestro-audio-player audio') as HTMLAudioElement | null)?.currentTime ?? -1
+        )
+      )
+      .toBeGreaterThanOrEqual(0);
+    const playheadSeconds = await page.evaluate(
+      () => (document.querySelector('.maestro-audio-player audio') as HTMLAudioElement | null)?.currentTime ?? -1
+    );
+    expect(playheadSeconds).toBeLessThan(30);
+  });
+
+  await test.step('pausing from the player is written to the session', async () => {
+    await page.getByRole('button', { name: 'Pause' }).click();
+
+    await expect
+      .poll(async () => {
+        const response = await fetch(`${RPG_MAESTRO_URL}/sessions/${user.sessionId}/playing-tracks`);
+        const state = (await response.json()) as { currentTrack: { isPaused: boolean } };
+        return state.currentTrack.isPaused;
+      })
+      .toBe(true);
+  });
+
+  await test.step('and it did so without logging an error', () => {
+    // A pause landing on a play() that is still starting up rejects with AbortError. That is normal, and
+    // used to be reported as "An unexpected error occurred" — this asserts it no longer is.
+    // Autoplay being blocked stays excluded: it depends on the browser's policy, not on this code.
+    const unexpected = consoleErrors.filter((error) => !/autoplay|NotAllowedError|user interaction/i.test(error));
+    expect(pageErrors).toEqual([]);
+    expect(unexpected).toEqual([]);
+  });
+});

--- a/apps/rpg-maestro-ui-e2e/src/players-ui.spec.ts
+++ b/apps/rpg-maestro-ui-e2e/src/players-ui.spec.ts
@@ -209,3 +209,51 @@ test('the Players UI updates the displayed track name when the Maestro changes t
     await expect(page.getByText(firstTrackName)).not.toBeVisible();
   });
 });
+
+test('the Players UI is kept up to date by the push stream alone, with polling blocked', async ({ page }) => {
+  let user: UserWithGeneratedSession;
+  let firstTrackName: string;
+  let secondTrackName: string;
+  let secondTrackId: string;
+  let pollCount = 0;
+
+  await test.step('prepare data: two tracks, first one playing', async () => {
+    user = await generateNewSession(userFixture.a_maestro_user);
+
+    const first = await createTrackViaApi(user, user.sessionId, {
+      url: `${RPG_MAESTRO_URL}/public/race1.ogg`,
+      name: 'first-track-push-test',
+    });
+    firstTrackName = first.name;
+
+    const second = await createTrackViaApi(user, user.sessionId, {
+      url: `${RPG_MAESTRO_URL}/public/race1.ogg`,
+      name: 'second-track-push-test',
+    });
+    secondTrackName = second.name;
+    secondTrackId = second.id;
+
+    await setTrackToPlayViaApi(user, user.sessionId, first.id);
+  });
+
+  await test.step('cut the polling endpoint, leaving only the SSE stream', async () => {
+    // The glob stops at the path segment, so the stream route (…/playing-tracks/stream) is untouched:
+    // whatever the player displays from here on can only have been pushed.
+    await page.route('**/sessions/*/playing-tracks', (route) => {
+      pollCount++;
+      return route.abort();
+    });
+  });
+
+  await test.step('the stream alone gets the player playing the current track', async () => {
+    await page.goto(`/${user.sessionId}`);
+    await expect(page.getByText(firstTrackName)).toBeVisible();
+  });
+
+  await test.step('and the stream alone carries the Maestro next track change', async () => {
+    await setTrackToPlayViaApi(user, user.sessionId, secondTrackId);
+
+    await expect(page.getByText(secondTrackName)).toBeVisible();
+    expect(pollCount).toBeGreaterThan(0);
+  });
+});

--- a/apps/rpg-maestro-ui/src/app/maestro-ui/maestro-audio-player/maestro-audio-player.tsx
+++ b/apps/rpg-maestro-ui/src/app/maestro-ui/maestro-audio-player/maestro-audio-player.tsx
@@ -6,6 +6,8 @@ import { resyncIfNeeded } from '../../track-sync/track-sync';
 import { displayError } from '../../error-utils';
 import './maestro-audio-player.css';
 import { AbortedRequestError } from '../maestro-api';
+import { serverNow, startServerTimeSync } from '../../utils/server-time';
+import { startPlayback } from '../../utils/start-playback';
 
 export interface MaestroAudioPlayerRef {
   dispatchTrackWasManuallyChanged: (newTracks: SessionPlayingTracks) => void;
@@ -57,7 +59,7 @@ export const MaestroAudioPlayer = forwardRef((props: MaestroAudioPlayerProps, re
                 audioPlayer.current.audio.current.src = trackFromServer.url;
               }
               audioPlayer.current.audio.current.title = trackFromServer.name;
-              const currentPlayTime = trackFromServer.getCurrentPlayTime();
+              const currentPlayTime = trackFromServer.getCurrentPlayTime(serverNow());
               if (currentPlayTime) {
                 audioPlayer.current.audio.current.currentTime = currentPlayTime / 1000;
               }
@@ -66,18 +68,7 @@ export const MaestroAudioPlayer = forwardRef((props: MaestroAudioPlayerProps, re
                 audioPlayer.current.audio.current.pause();
               } else {
                 // playing
-                try {
-                  await audioPlayer.current.audio.current.play();
-                } catch (error) {
-                  if (error instanceof DOMException && error.name === 'NotAllowedError') {
-                    console.error(
-                      `Play failed: User interaction with the document is required first. Original error: ${error}`
-                    );
-                    displayError('This is your first time using the app, please accept autoplay by hitting play :)');
-                  } else {
-                    console.error('An unexpected error occurred:', error);
-                  }
-                }
+                await startPlayback(audioPlayer.current.audio.current);
               }
             } else {
               console.warn('audio player not available yet');
@@ -122,6 +113,7 @@ export const MaestroAudioPlayer = forwardRef((props: MaestroAudioPlayerProps, re
         audioPlayer.current?.audio?.current?.currentTime ?? null,
         currentTrack,
         null,
+        serverNow()
       ).then((syncResult) => {
         if (syncResult === 'SessionNotFoundError') {
           // Not terminal for a Maestro: upsertCurrentTrack creates the session, so playing a track
@@ -141,6 +133,10 @@ export const MaestroAudioPlayer = forwardRef((props: MaestroAudioPlayerProps, re
     const request = requestFunc();
     await request;
   }, [currentTrackEditRequested, sessionId, currentTrack, resyncCurrentTrackOnUi]);
+
+  // Playback positions are timestamps on the server's clock, so this browser's own clock is not a
+  // usable reference for them, see utils/server-time.ts.
+  useEffect(() => startServerTimeSync(), []);
 
   useEffect(() => {
     periodicallySyncCurrentTrack();
@@ -167,7 +163,7 @@ export const MaestroAudioPlayer = forwardRef((props: MaestroAudioPlayerProps, re
       if (currentTrack.isPaused !== newPausedStatus) {
         // trying to handle load edge cases
         console.info(`changePlayingStatus newPausedStatus: ${newPausedStatus}`);
-        const stoppedTime = currentTrack.getCurrentPlayTime();
+        const stoppedTime = currentTrack.getCurrentPlayTime(serverNow());
         currentTrack.trackStartTime = stoppedTime;
         currentTrack.isPaused = newPausedStatus;
         await requestCurrentTrackEdit({

--- a/apps/rpg-maestro-ui/src/app/players-ui/players-ui.tsx
+++ b/apps/rpg-maestro-ui/src/app/players-ui/players-ui.tsx
@@ -1,10 +1,14 @@
 import AudioPlayer from 'react-h5-audio-player';
 import H5AudioPlayer from 'react-h5-audio-player';
 import { ToastContainer } from 'react-toastify';
-import React, { LegacyRef, useEffect, useRef, useState } from 'react';
-import { resyncIfNeeded } from '../track-sync/track-sync';
+import React, { LegacyRef, useCallback, useEffect, useRef, useState } from 'react';
+import { resolveSync } from '../track-sync/track-sync';
+import { subscribeToSessionPlayingTracks } from '../track-sync/session-stream';
 import { displayError } from '../error-utils';
-import { PlayingTrack } from '@rpg-maestro/rpg-maestro-api-contract';
+import { PlayingTrack, SessionPlayingTracks } from '@rpg-maestro/rpg-maestro-api-contract';
+import { getSessionPlayingTracks } from '../tracks-api';
+import { serverNow, startServerTimeSync } from '../utils/server-time';
+import { startPlayback } from '../utils/start-playback';
 import GithubSourceCodeLink from '../ui-components/github-source-code-link/github-source-code-link';
 import './audio-player-readonly.css';
 import MusicNoteIcon from '@mui/icons-material/MusicNote';
@@ -13,7 +17,16 @@ import SpatialAudioOffIcon from '@mui/icons-material/SpatialAudioOff';
 import { useParams } from 'react-router';
 import { Typography } from '@mui/material';
 
+/** How often the session is polled while the push stream is down. */
 export const SYNC_TRACK_INTERVAL_MS = 1000;
+
+/**
+ * How often the session is polled while the push stream *is* up. The stream carries every change, so
+ * this is only there to close the gap the stream cannot: an event dropped by a proxy, or a fanout that
+ * did not reach this instance. Rare enough that a slow poll is the right price — which is the whole
+ * point of the stream, since a room of listeners polling every second scales with the room.
+ */
+export const SYNC_TRACK_FALLBACK_INTERVAL_MS = 15000;
 
 /**
  * How many consecutive 404s before we tell the player the session does not exist and stop polling.
@@ -25,13 +38,18 @@ export const CONSECUTIVE_NOT_FOUND_BEFORE_GIVING_UP = 3;
 
 export function PlayersUi() {
   const [currentTrack, setCurrentTrack] = useState<PlayingTrack | null>(null);
-  const [shortEffectTrack, setShortEffectTrack] = useState<PlayingTrack | null>(null);
   const [sessionNotFound, setSessionNotFound] = useState(false);
+  const [streamConnected, setStreamConnected] = useState(false);
   const consecutiveNotFound = useRef(0);
   const audioPlayer = useRef<H5AudioPlayer>();
   const effectAudioRef = useRef<HTMLAudioElement>(null);
   const sessionId = useParams().sessionId ?? '';
   const latestSessionId = useRef(sessionId);
+  // What is playing here right now, as a ref and not just as state: the stream's handler is registered
+  // once per session and would otherwise keep comparing against whatever was playing when it was
+  // registered.
+  const localCurrentTrack = useRef<PlayingTrack | null>(null);
+  const localShortEffectTrack = useRef<PlayingTrack | null>(null);
   if (sessionId === '') {
     displayError('no session found in URL (it should be https://{URL}/session/{sessionId})');
   }
@@ -43,6 +61,78 @@ export function PlayersUi() {
     consecutiveNotFound.current = 0;
   }, [sessionId]);
 
+  // Playback positions are timestamps on the server's clock, so this browser's own clock is not a
+  // usable reference for them, see utils/server-time.ts.
+  useEffect(() => startServerTimeSync(), []);
+
+  /**
+   * Brings the audio in line with a state the server reported — whether it was pushed over the stream
+   * or fetched by the fallback poll below. Both go through here so that a change sounds the same
+   * whichever way it arrived.
+   */
+  const applyServerState = useCallback(async (serverState: SessionPlayingTracks) => {
+    const syncResult = resolveSync(
+      serverState,
+      audioPlayer.current?.audio?.current?.currentTime ?? null,
+      localCurrentTrack.current,
+      localShortEffectTrack.current,
+      serverNow()
+    );
+
+    // Handle current track sync
+    const newerServerTrack = syncResult.currentTrack;
+    if (newerServerTrack) {
+      console.info('synchronizing track');
+      localCurrentTrack.current = newerServerTrack;
+      setCurrentTrack(newerServerTrack);
+      if (audioPlayer.current?.audio?.current) {
+        if (audioPlayer.current.audio.current.src !== newerServerTrack.url) {
+          audioPlayer.current.audio.current.src = newerServerTrack.url;
+        }
+        audioPlayer.current.audio.current.title = newerServerTrack.name;
+        const currentPlayTime = newerServerTrack.getCurrentPlayTime(serverNow());
+        audioPlayer.current.audio.current.currentTime = currentPlayTime / 1000;
+        if (newerServerTrack.isPaused) {
+          audioPlayer.current.audio.current.pause();
+        } else {
+          await startPlayback(audioPlayer.current.audio.current);
+        }
+      } else {
+        console.warn('audio player not available yet');
+      }
+    }
+
+    // Handle short effect track
+    const newEffect = syncResult.shortEffectTrack;
+    if (newEffect && effectAudioRef.current) {
+      console.info('playing short effect track:', newEffect.name);
+      localShortEffectTrack.current = newEffect;
+      effectAudioRef.current.src = newEffect.url;
+      effectAudioRef.current.currentTime = 0;
+      try {
+        await effectAudioRef.current.play();
+      } catch (error) {
+        console.error('Failed to play short effect track:', error);
+      }
+    }
+  }, []);
+
+  // The push channel: one connection per listener, fed by the Maestro's writes wherever they landed.
+  useEffect(() => {
+    // A session that does not exist has nothing to push, and its stream would only 404 in a loop.
+    if (sessionNotFound) {
+      return;
+    }
+    return subscribeToSessionPlayingTracks(sessionId, {
+      onTracks: (tracks) => {
+        // Pushed state cannot tell us a session is missing — that is what the poll's 404s are for — so
+        // the strike counter is left alone here.
+        applyServerState(tracks);
+      },
+      onStatusChange: (status) => setStreamConnected(status === 'connected'),
+    });
+  }, [sessionId, sessionNotFound, applyServerState]);
+
   useEffect(() => {
     // Polling a session that does not exist can never succeed, so no interval is set up at all.
     if (sessionNotFound) {
@@ -50,86 +140,35 @@ export function PlayersUi() {
     }
 
     async function resyncOnUi() {
-      // Keyed on the session the request was issued for, not on effect teardown: this effect re-runs
-      // whenever the playing track changes, and dropping a response on every re-run could starve
-      // the consecutive-404 counter below and leave a missing session undetected forever.
+      // Keyed on the session the request was issued for, not on effect teardown: dropping a response
+      // on every re-run could starve the consecutive-404 counter below and leave a missing session
+      // undetected forever.
       const requestedFor = sessionId;
-      const syncResult = await resyncIfNeeded(
-        sessionId,
-        audioPlayer.current?.audio?.current?.currentTime ?? null,
-        currentTrack,
-        shortEffectTrack,
-      );
+      const serverState = await getSessionPlayingTracks(sessionId);
       if (requestedFor !== latestSessionId.current) {
         return;
       }
-      if (syncResult === 'AbortedRequestError') {
+      if (serverState === 'AbortedRequestError') {
         return;
       }
-      if (syncResult === 'SessionNotFoundError') {
+      if (serverState === 'SessionNotFoundError') {
         consecutiveNotFound.current += 1;
         if (consecutiveNotFound.current >= CONSECUTIVE_NOT_FOUND_BEFORE_GIVING_UP) {
-          // Flipping this re-runs the effect, whose cleanup clears the interval below.
+          // Flipping this re-runs both effects, whose cleanups stop the interval and the stream.
           setSessionNotFound(true);
         }
         return;
       }
       consecutiveNotFound.current = 0;
-
-      // Handle current track sync
-      const newerServerTrack = syncResult.currentTrack;
-      if (newerServerTrack) {
-        console.info('synchronizing track');
-        setCurrentTrack(newerServerTrack);
-        if (audioPlayer.current?.audio?.current) {
-          if (audioPlayer.current.audio.current.src !== newerServerTrack.url) {
-            audioPlayer.current.audio.current.src = newerServerTrack.url;
-          }
-          audioPlayer.current.audio.current.title = newerServerTrack.name;
-          const currentPlayTime = newerServerTrack.getCurrentPlayTime();
-          audioPlayer.current.audio.current.currentTime = currentPlayTime / 1000;
-          if (newerServerTrack.isPaused) {
-            audioPlayer.current.audio.current.pause();
-          } else {
-            try {
-              await audioPlayer.current.audio.current.play();
-            } catch (error) {
-              if (error instanceof DOMException && error.name === 'NotAllowedError') {
-                console.error(
-                  `Play failed: User interaction with the document is required first. Original error: ${error}`
-                );
-                displayError('This is your first time using the app, please accept autoplay by hitting play :)');
-              } else {
-                console.error('An unexpected error occurred:', error);
-              }
-            }
-          }
-        } else {
-          console.warn('audio player not available yet');
-        }
-      }
-
-      // Handle short effect track
-      const newEffect = syncResult.shortEffectTrack;
-      if (newEffect && effectAudioRef.current) {
-        console.info('playing short effect track:', newEffect.name);
-        setShortEffectTrack(newEffect);
-        effectAudioRef.current.src = newEffect.url;
-        effectAudioRef.current.currentTime = 0;
-        try {
-          await effectAudioRef.current.play();
-        } catch (error) {
-          console.error('Failed to play short effect track:', error);
-        }
-      }
+      await applyServerState(serverState);
     }
 
     resyncOnUi();
     const id = setInterval(() => {
       resyncOnUi();
-    }, SYNC_TRACK_INTERVAL_MS);
+    }, streamConnected ? SYNC_TRACK_FALLBACK_INTERVAL_MS : SYNC_TRACK_INTERVAL_MS);
     return () => clearInterval(id);
-  }, [currentTrack, shortEffectTrack, sessionId, sessionNotFound]);
+  }, [sessionId, sessionNotFound, streamConnected, applyServerState]);
 
   return (
     <div style={{ display: 'flex', flexDirection: 'column', justifyContent: 'space-around', alignItems: 'center', minHeight: '100vh', padding: '2rem' }}>

--- a/apps/rpg-maestro-ui/src/app/track-sync/session-stream.ts
+++ b/apps/rpg-maestro-ui/src/app/track-sync/session-stream.ts
@@ -1,0 +1,79 @@
+import { SessionPlayingTracks } from '@rpg-maestro/rpg-maestro-api-contract';
+import { deserializeSessionPlayingTracks } from '../tracks-api';
+import { rpgMaestroApiUrl } from '../utils/api-config';
+
+/**
+ * The server-sent-events stream of a session's playing tracks.
+ *
+ * This is what keeps a room of listeners from each polling on their own: the server pushes a track
+ * change once, to everyone. Polling stays in place as a safety net — see `SYNC_TRACK_INTERVAL_MS` in
+ * the player UI — because a stream can be cut by anything between the browser and the app, and a
+ * silent stream is indistinguishable from a session where nothing happens.
+ */
+
+/** The stream is a snapshot of the whole session state, matching what the poll returns. */
+export const PLAYING_TRACKS_EVENT = 'playing-tracks';
+
+/**
+ * How long before a stream the browser gave up on is opened again. `EventSource` reconnects by itself
+ * while the server is merely unreachable, but stops for good on an HTTP error — a 404 for a session
+ * the Maestro has not created yet, most importantly.
+ */
+export const RECONNECT_DELAY_MS = 10000;
+
+export type SessionStreamStatus = 'connected' | 'disconnected';
+
+export interface SessionStreamHandlers {
+  onTracks: (tracks: SessionPlayingTracks) => void;
+  /** Called on every change, so the caller can slow its fallback poll down while the stream is up. */
+  onStatusChange: (status: SessionStreamStatus) => void;
+}
+
+/**
+ * Streams a session's playing tracks. Returns the function that stops it — the caller must call it,
+ * or the browser keeps the connection and its reconnect loop alive.
+ */
+export function subscribeToSessionPlayingTracks(sessionId: string, handlers: SessionStreamHandlers): () => void {
+  let stopped = false;
+  let source: EventSource | null = null;
+  let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+
+  const open = () => {
+    if (stopped) {
+      return;
+    }
+    source = new EventSource(`${rpgMaestroApiUrl}/sessions/${sessionId}/playing-tracks/stream`);
+
+    source.onopen = () => handlers.onStatusChange('connected');
+
+    source.addEventListener(PLAYING_TRACKS_EVENT, (event) => {
+      try {
+        handlers.onTracks(deserializeSessionPlayingTracks(JSON.parse((event as MessageEvent<string>).data)));
+      } catch (error) {
+        console.warn('dropping an unreadable playing-tracks event', error);
+      }
+    });
+
+    source.onerror = () => {
+      handlers.onStatusChange('disconnected');
+      // No error is surfaced to the user: the fallback poll covers this, and a listener who can still
+      // hear the music has nothing to act on.
+      if (source?.readyState === EventSource.CLOSED) {
+        source.close();
+        source = null;
+        reconnectTimer = setTimeout(open, RECONNECT_DELAY_MS);
+      }
+    };
+  };
+
+  open();
+
+  return () => {
+    stopped = true;
+    if (reconnectTimer) {
+      clearTimeout(reconnectTimer);
+    }
+    source?.close();
+    source = null;
+  };
+}

--- a/apps/rpg-maestro-ui/src/app/track-sync/track-sync.spec.ts
+++ b/apps/rpg-maestro-ui/src/app/track-sync/track-sync.spec.ts
@@ -1,16 +1,12 @@
 import {
   isCurrentTrackOutOfDate,
   isCurrentTrackTooMuchDesynchronizedFromServer,
+  resolveSync,
 } from './track-sync';
-import { afterAll, describe } from 'vitest';
-import { PlayingTrack } from '@rpg-maestro/rpg-maestro-api-contract';
+import { describe } from 'vitest';
+import { PlayingTrack, SessionPlayingTracks } from '@rpg-maestro/rpg-maestro-api-contract';
 
-const NOW = new Date(1730000015000);
-
-beforeAll(() => {
-  vi.useFakeTimers();
-  vi.setSystemTime(NOW);
-});
+const SERVER_NOW = 1730000015000;
 describe('track-sync tests', () => {
   describe('isCurrentTrackTooMuchDesynchronizedFromServer', () => {
     const serverTrackRunningFor15Seconds = new PlayingTrack(
@@ -27,7 +23,8 @@ describe('track-sync tests', () => {
       expect(
         isCurrentTrackTooMuchDesynchronizedFromServer(
           currentTrack,
-          serverTrackRunningFor15Seconds
+          serverTrackRunningFor15Seconds,
+          SERVER_NOW
         )
       ).toBeTruthy();
     });
@@ -36,7 +33,8 @@ describe('track-sync tests', () => {
       expect(
         isCurrentTrackTooMuchDesynchronizedFromServer(
           currentTrack,
-          serverTrackRunningFor15Seconds
+          serverTrackRunningFor15Seconds,
+          SERVER_NOW
         )
       ).toBeFalsy();
     });
@@ -45,7 +43,8 @@ describe('track-sync tests', () => {
       expect(
         isCurrentTrackTooMuchDesynchronizedFromServer(
           currentTrack,
-          serverTrackRunningFor15Seconds
+          serverTrackRunningFor15Seconds,
+          SERVER_NOW
         )
       ).toBeFalsy();
     });
@@ -159,6 +158,55 @@ describe('track-sync tests', () => {
     });
   });
 });
-afterAll(() => {
-  vi.useRealTimers();
+
+describe('resolveSync', () => {
+  const aTrack = (id: string, playTimestamp: number) => new PlayingTrack(id, id, 'url', 120000, false, playTimestamp, 0);
+  const serverState = (currentTrack: PlayingTrack | null, shortEffectTrack: PlayingTrack | null = null): SessionPlayingTracks => ({
+    sessionId: 'a-session',
+    currentTrack,
+    shortEffectTrack,
+  });
+
+  it('hands back the server track when the browser has nothing playing yet', () => {
+    const serverTrack = aTrack('1', 1730000000000);
+
+    expect(resolveSync(serverState(serverTrack), null, null, null, SERVER_NOW).currentTrack).toBe(serverTrack);
+  });
+
+  it('asks for no change when the browser already plays that track at that position', () => {
+    const serverTrack = aTrack('1', 1730000000000);
+    const playTimeInSeconds = 15;
+
+    expect(resolveSync(serverState(serverTrack), playTimeInSeconds, aTrack('1', 1730000000000), null, SERVER_NOW))
+      .toEqual({ currentTrack: null, shortEffectTrack: null });
+  });
+
+  it('hands back the server track when the Maestro switched track', () => {
+    const serverTrack = aTrack('2', 1730000000000);
+
+    expect(resolveSync(serverState(serverTrack), 15, aTrack('1', 1730000000000), null, SERVER_NOW).currentTrack).toBe(
+      serverTrack
+    );
+  });
+
+  it('replays a short effect only when it is a new one', () => {
+    const effect = aTrack('effect', 1730000010000);
+
+    expect(resolveSync(serverState(null, effect), null, null, effect, SERVER_NOW).shortEffectTrack).toBeNull();
+    expect(resolveSync(serverState(null, effect), null, null, aTrack('effect', 1730000005000), SERVER_NOW).shortEffectTrack).toBe(
+      effect
+    );
+  });
+
+  it('decides on the server clock it is given, not on this browser one', () => {
+    // A browser one hour behind: reading the playhead on its own clock would put the server track an
+    // hour into the past, and the desync check would fire on every single sync.
+    const serverTrack = aTrack('1', SERVER_NOW - 15000);
+    const anHourBehind = SERVER_NOW - 3600_000;
+
+    expect(resolveSync(serverState(serverTrack), 15, aTrack('1', SERVER_NOW - 15000), null, SERVER_NOW).currentTrack).toBeNull();
+    expect(resolveSync(serverState(serverTrack), 15, aTrack('1', SERVER_NOW - 15000), null, anHourBehind).currentTrack).toBe(
+      serverTrack
+    );
+  });
 });

--- a/apps/rpg-maestro-ui/src/app/track-sync/track-sync.ts
+++ b/apps/rpg-maestro-ui/src/app/track-sync/track-sync.ts
@@ -13,28 +13,48 @@ export interface SyncResult {
  * @param currentTrackPlayTime the requested play time of the track
  * @param currentTrack the current track in the browser
  * @param localShortEffectTrack the current short effect track in the browser
+ * @param serverNowMs the current time on the server clock, see `utils/server-time.ts`
  */
 export const resyncIfNeeded = async (
   sessionId: string,
   currentTrackPlayTime: number | null,
   currentTrack: PlayingTrack | null,
   localShortEffectTrack: PlayingTrack | null,
+  serverNowMs: number
 ): Promise<SyncResult | AbortedRequestError | SessionNotFoundError> => {
   const serverState = await getSessionPlayingTracks(sessionId);
   if (serverState === 'AbortedRequestError' || serverState === 'SessionNotFoundError') {
     return serverState;
   }
 
-  const newCurrentTrack = resolveCurrentTrackSync(currentTrackPlayTime, currentTrack, serverState);
-  const newShortEffect = resolveShortEffectSync(localShortEffectTrack, serverState.shortEffectTrack);
-
-  return { currentTrack: newCurrentTrack, shortEffectTrack: newShortEffect };
+  return resolveSync(serverState, currentTrackPlayTime, currentTrack, localShortEffectTrack, serverNowMs);
 };
+
+/**
+ * What the browser has to change to match the server, given a state it already holds.
+ *
+ * Split out of the fetch above because that state now arrives two ways — pushed over the stream, or
+ * pulled by the fallback poll — and both have to decide identically. A pushed event taking a different
+ * path here would show up as playback that is right or wrong depending on how it was delivered.
+ */
+export function resolveSync(
+  serverState: SessionPlayingTracks,
+  currentTrackPlayTime: number | null,
+  currentTrack: PlayingTrack | null,
+  localShortEffectTrack: PlayingTrack | null,
+  serverNowMs: number
+): SyncResult {
+  return {
+    currentTrack: resolveCurrentTrackSync(currentTrackPlayTime, currentTrack, serverState, serverNowMs),
+    shortEffectTrack: resolveShortEffectSync(localShortEffectTrack, serverState.shortEffectTrack),
+  };
+}
 
 function resolveCurrentTrackSync(
   currentTrackPlayTime: number | null,
   currentTrack: PlayingTrack | null,
   serverState: SessionPlayingTracks,
+  serverNowMs: number
 ): PlayingTrack | null {
   const serverTrack = serverState.currentTrack;
   if (!serverTrack) {
@@ -45,7 +65,7 @@ function resolveCurrentTrackSync(
     currentTrackPlayTime === undefined ||
     !currentTrack ||
     isCurrentTrackOutOfDate(currentTrack, serverTrack) ||
-    isCurrentTrackTooMuchDesynchronizedFromServer(currentTrackPlayTime * 1000, serverTrack)
+    isCurrentTrackTooMuchDesynchronizedFromServer(currentTrackPlayTime * 1000, serverTrack, serverNowMs)
   ) {
     return serverTrack;
   }
@@ -54,7 +74,7 @@ function resolveCurrentTrackSync(
 
 function resolveShortEffectSync(
   localEffectTrack: PlayingTrack | null,
-  serverEffectTrack: PlayingTrack | null,
+  serverEffectTrack: PlayingTrack | null
 ): PlayingTrack | null {
   if (!serverEffectTrack) {
     return null;
@@ -67,9 +87,10 @@ function resolveShortEffectSync(
 
 export const isCurrentTrackTooMuchDesynchronizedFromServer = (
   currentTrackPlayTime: number,
-  serverTrack: PlayingTrack
+  serverTrack: PlayingTrack,
+  serverNowMs: number
 ): boolean => {
-  const serverPlayTime = serverTrack.getCurrentPlayTime();
+  const serverPlayTime = serverTrack.getCurrentPlayTime(serverNowMs);
   if (!serverPlayTime && serverPlayTime !== 0) {
     return false;
   }

--- a/apps/rpg-maestro-ui/src/app/tracks-api.ts
+++ b/apps/rpg-maestro-ui/src/app/tracks-api.ts
@@ -10,6 +10,18 @@ interface OngoingRequest {
   startTimeMs: number;
 }
 
+/**
+ * Rebuilds the class instances JSON cannot carry: `PlayingTrack.getCurrentPlayTime()` is behaviour,
+ * and the parsed payload is only data.
+ */
+export function deserializeSessionPlayingTracks(raw: SessionPlayingTracks): SessionPlayingTracks {
+  return {
+    sessionId: raw.sessionId,
+    currentTrack: raw.currentTrack ? deserializePlayingTrack(raw.currentTrack) : null,
+    shortEffectTrack: raw.shortEffectTrack ? deserializePlayingTrack(raw.shortEffectTrack) : null,
+  };
+}
+
 function deserializePlayingTrack(track: PlayingTrack): PlayingTrack {
   return new PlayingTrack(
     track.id,
@@ -49,11 +61,7 @@ export const getSessionPlayingTracks = async (
     if (response.ok) {
       const res = (await response.json()) as SessionPlayingTracks;
       ongoingRequest = null;
-      return {
-        sessionId: res.sessionId,
-        currentTrack: res.currentTrack ? deserializePlayingTrack(res.currentTrack) : null,
-        shortEffectTrack: res.shortEffectTrack ? deserializePlayingTrack(res.shortEffectTrack) : null,
-      };
+      return deserializeSessionPlayingTracks(res);
     } else if (response.status === 404) {
       // Expected outcome for a mistyped or stale session link, not a transport failure: report it as
       // a distinct result so the caller can stop polling, and skip the error toast that would

--- a/apps/rpg-maestro-ui/src/app/utils/server-time.spec.ts
+++ b/apps/rpg-maestro-ui/src/app/utils/server-time.spec.ts
@@ -1,0 +1,86 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  bestOffset,
+  getServerTimeOffsetMs,
+  measureOffset,
+  resetServerTimeOffset,
+  serverNow,
+  syncServerTime,
+} from './server-time';
+
+const fetchMock = vi.fn();
+
+describe('measureOffset', () => {
+  it('assumes the server read its clock halfway through the round trip', () => {
+    // server said 5100 at what was, from here, local time 1100
+    expect(measureOffset({ sentAt: 1000, serverTime: 5100, receivedAt: 1200 })).toEqual({
+      offsetMs: 4000,
+      roundTripMs: 200,
+    });
+  });
+
+  it('reports no offset when this clock already agrees with the server', () => {
+    expect(measureOffset({ sentAt: 1000, serverTime: 1050, receivedAt: 1100 })).toEqual({
+      offsetMs: 0,
+      roundTripMs: 100,
+    });
+  });
+});
+
+describe('bestOffset', () => {
+  it('keeps the sample with the shortest round trip, since a slow response hides an asymmetric delay', () => {
+    const fast = { sentAt: 1000, serverTime: 1010, receivedAt: 1020 };
+    const slow = { sentAt: 2000, serverTime: 2010, receivedAt: 3000 };
+
+    expect(bestOffset([slow, fast])).toEqual({ offsetMs: 0, roundTripMs: 20 });
+  });
+
+  it('has nothing to say when no sample was taken', () => {
+    expect(bestOffset([])).toBeNull();
+  });
+});
+
+describe('syncServerTime', () => {
+  beforeEach(() => {
+    resetServerTimeOffset();
+    fetchMock.mockReset();
+    vi.stubGlobal('fetch', fetchMock);
+  });
+
+  afterEach(() => {
+    resetServerTimeOffset();
+    vi.unstubAllGlobals();
+  });
+
+  it('corrects this browser clock towards the server one', async () => {
+    const oneHourAhead = Date.now() + 3600_000;
+    fetchMock.mockResolvedValue({ ok: true, json: async () => ({ serverTime: oneHourAhead }) });
+
+    await syncServerTime();
+
+    expect(getServerTimeOffsetMs()).toBeGreaterThan(3599_000);
+    expect(serverNow()).toBeGreaterThan(oneHourAhead - 1000);
+  });
+
+  it('leaves the offset alone when the server cannot be reached', async () => {
+    const oneHourAhead = Date.now() + 3600_000;
+    fetchMock.mockResolvedValue({ ok: true, json: async () => ({ serverTime: oneHourAhead }) });
+    await syncServerTime();
+    const measuredOffset = getServerTimeOffsetMs();
+    fetchMock.mockRejectedValue(new Error('offline'));
+
+    await syncServerTime();
+
+    // A stale offset is far closer to the truth than falling back to this browser's raw clock, and a
+    // failed refresh is no reason to stop the music.
+    expect(getServerTimeOffsetMs()).toBe(measuredOffset);
+  });
+
+  it('does not trust a non-ok answer', async () => {
+    fetchMock.mockResolvedValue({ ok: false, status: 503, json: async () => ({ serverTime: 0 }) });
+
+    await syncServerTime();
+
+    expect(getServerTimeOffsetMs()).toBe(0);
+  });
+});

--- a/apps/rpg-maestro-ui/src/app/utils/server-time.ts
+++ b/apps/rpg-maestro-ui/src/app/utils/server-time.ts
@@ -1,0 +1,125 @@
+import { ServerTime } from '@rpg-maestro/rpg-maestro-api-contract';
+import { rpgMaestroApiUrl } from './api-config';
+
+/**
+ * The browser's estimate of the server clock.
+ *
+ * Playback positions are reconstructed from `PlayingTrack.playTimestamp`, which the server stamps on
+ * *its* clock. A browser's `Date.now()` is routinely seconds away from it — nothing forces a laptop's
+ * clock to be right — and that whole error lands on the playhead, so two listeners in the same room
+ * would sit seconds apart in the same track. Measuring the offset once and correcting for it removes
+ * that error, and leaves only what the measurement itself is worth: half a round trip, so tens of
+ * milliseconds, which nobody hears.
+ */
+
+/** How often the offset is measured again, to follow the browser clock's own drift. */
+export const RESYNC_INTERVAL_MS = 5 * 60 * 1000;
+
+/** Reads per measurement. The one with the shortest round trip wins, see {@link bestOffset}. */
+export const SAMPLES_PER_RESYNC = 3;
+
+export interface ServerTimeSample {
+  /** Local epoch ms just before the request went out. */
+  sentAt: number;
+  /** What the server answered. */
+  serverTime: number;
+  /** Local epoch ms just after the answer came back. */
+  receivedAt: number;
+}
+
+export interface ServerTimeMeasurement {
+  /** Add this to `Date.now()` to get the server's clock. */
+  offsetMs: number;
+  roundTripMs: number;
+}
+
+/**
+ * NTP's estimator: the server read its clock somewhere inside our round trip, and the midpoint is the
+ * least-wrong guess as to when.
+ */
+export function measureOffset(sample: ServerTimeSample): ServerTimeMeasurement {
+  const roundTripMs = sample.receivedAt - sample.sentAt;
+  return {
+    offsetMs: sample.serverTime + roundTripMs / 2 - sample.receivedAt,
+    roundTripMs,
+  };
+}
+
+/**
+ * The shortest round trip, not the average: a slow response is slow because something queued, and
+ * queueing is asymmetric — exactly what the midpoint guess above cannot model. Averaging would fold
+ * that error in instead of throwing it away.
+ */
+export function bestOffset(samples: ServerTimeSample[]): ServerTimeMeasurement | null {
+  return samples
+    .map(measureOffset)
+    .reduce<ServerTimeMeasurement | null>(
+      (best, measurement) => (best === null || measurement.roundTripMs < best.roundTripMs ? measurement : best),
+      null
+    );
+}
+
+let offsetMs = 0;
+
+/** Epoch ms on the server clock, as best as this browser can tell. */
+export function serverNow(): number {
+  return Date.now() + offsetMs;
+}
+
+export function getServerTimeOffsetMs(): number {
+  return offsetMs;
+}
+
+async function readServerTime(): Promise<ServerTimeSample | null> {
+  try {
+    const sentAt = Date.now();
+    const response = await fetch(`${rpgMaestroApiUrl}/server-time`);
+    const receivedAt = Date.now();
+    if (!response.ok) {
+      return null;
+    }
+    const { serverTime } = (await response.json()) as ServerTime;
+    return { sentAt, serverTime, receivedAt };
+  } catch (error) {
+    console.warn('could not read the server time', error);
+    return null;
+  }
+}
+
+/**
+ * Measures the offset against the server clock.
+ *
+ * A failure is deliberately silent, and leaves the previous offset in place: the offset only makes
+ * playback *more* accurate, so failing to refresh it is no reason to bother the user — the audio keeps
+ * playing either way.
+ */
+export async function syncServerTime(): Promise<void> {
+  const samples: ServerTimeSample[] = [];
+  for (let i = 0; i < SAMPLES_PER_RESYNC; i++) {
+    const sample = await readServerTime();
+    if (!sample) {
+      break;
+    }
+    samples.push(sample);
+  }
+  const measurement = bestOffset(samples);
+  if (!measurement) {
+    return;
+  }
+  offsetMs = Math.round(measurement.offsetMs);
+  console.info(`clock is ${offsetMs}ms off the server's, round trip ${measurement.roundTripMs}ms`);
+}
+
+/** Starts following the server clock. Returns the function that stops it. */
+export function startServerTimeSync(): () => void {
+  syncServerTime();
+  const id = setInterval(() => {
+    syncServerTime();
+  }, RESYNC_INTERVAL_MS);
+  return () => clearInterval(id);
+}
+
+/** For tests only: forgets the measured offset. */
+export function resetServerTimeOffset(): void {
+  offsetMs = 0;
+}

--- a/apps/rpg-maestro-ui/src/app/utils/start-playback.spec.ts
+++ b/apps/rpg-maestro-ui/src/app/utils/start-playback.spec.ts
@@ -1,0 +1,56 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { startPlayback } from './start-playback';
+import { displayError } from '../error-utils';
+
+vi.mock('../error-utils', () => ({ displayError: vi.fn() }));
+
+function audioRejecting(error: unknown): HTMLAudioElement {
+  return { play: () => Promise.reject(error) } as unknown as HTMLAudioElement;
+}
+
+describe('startPlayback', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.mocked(displayError).mockClear();
+  });
+
+  it('plays, and says nothing when that works', async () => {
+    const error = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    const play = vi.fn().mockResolvedValue(undefined);
+
+    await startPlayback({ play } as unknown as HTMLAudioElement);
+
+    expect(play).toHaveBeenCalledOnce();
+    expect(error).not.toHaveBeenCalled();
+    expect(displayError).not.toHaveBeenCalled();
+  });
+
+  it('asks the user to allow autoplay, which is the one case they can do something about', async () => {
+    vi.spyOn(console, 'error').mockImplementation(() => undefined);
+
+    await startPlayback(audioRejecting(new DOMException('blocked', 'NotAllowedError')));
+
+    expect(displayError).toHaveBeenCalledOnce();
+  });
+
+  it('treats a play superseded by a pause as normal, not as an error', async () => {
+    const error = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    const info = vi.spyOn(console, 'info').mockImplementation(() => undefined);
+
+    // What the browser throws when the Maestro pauses while a play() is still starting: the pause is the
+    // newer intent and has already won.
+    await startPlayback(audioRejecting(new DOMException('interrupted by a call to pause()', 'AbortError')));
+
+    expect(error).not.toHaveBeenCalled();
+    expect(displayError).not.toHaveBeenCalled();
+    expect(info).toHaveBeenCalledOnce();
+  });
+
+  it('still reports what it does not recognise', async () => {
+    const error = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+
+    await startPlayback(audioRejecting(new Error('decoder exploded')));
+
+    expect(error).toHaveBeenCalledOnce();
+  });
+});

--- a/apps/rpg-maestro-ui/src/app/utils/start-playback.ts
+++ b/apps/rpg-maestro-ui/src/app/utils/start-playback.ts
@@ -1,0 +1,28 @@
+import { displayError } from '../error-utils';
+
+/**
+ * Starts an audio element, sorting the ways `play()` can reject into the one the user has to act on and
+ * the ones that are business as usual.
+ *
+ * Shared by the Maestro player and the player page so a rejection means the same thing on both — they
+ * had drifted into two copies of the same catch block.
+ */
+export async function startPlayback(audio: HTMLAudioElement): Promise<void> {
+  try {
+    await audio.play();
+  } catch (error) {
+    if (error instanceof DOMException && error.name === 'NotAllowedError') {
+      console.error(`Play failed: User interaction with the document is required first. Original error: ${error}`);
+      displayError('This is your first time using the app, please accept autoplay by hitting play :)');
+      return;
+    }
+    if (error instanceof DOMException && error.name === 'AbortError') {
+      // A pause landed while this play() was still starting up, which is what happens every time the
+      // Maestro hits pause during a sync. The pause is the newer intent and it already won, so there is
+      // nothing wrong here — and reporting it as an error made it look like there was.
+      console.info(`play() was superseded by a pause: ${error.message}`);
+      return;
+    }
+    console.error('An unexpected error occurred:', error);
+  }
+}

--- a/apps/rpg-maestro/src/app/AuthenticatedMaestroController.ts
+++ b/apps/rpg-maestro/src/app/AuthenticatedMaestroController.ts
@@ -38,6 +38,7 @@ import { Roles } from './auth/roles.decorator';
 import { Role } from './auth/role.enum';
 import { SessionsService } from './sessions/sessions.service';
 import { TrackCollectionService } from './track-collection/track-collection.service';
+import { ServerClock } from './infrastructure/clock/server-clock';
 
 @ApiCookieAuth()
 @UseGuards(JwtAuthGuard, RolesGuard)
@@ -51,11 +52,13 @@ export class AuthenticatedMaestroController {
     @Inject(TrackService) private trackService: TrackService,
     @Inject(OnboardingService) private onboardingService: OnboardingService,
     @Inject(UsersService) private userService: UsersService,
-    @Inject(TrackCollectionService) private trackCollectionService: TrackCollectionService
+    @Inject(TrackCollectionService) private trackCollectionService: TrackCollectionService,
+    @Inject(ServerClock) serverClock: ServerClock
   ) {
     this.manageCurrentlyPlayingTracks = new ManageCurrentlyPlayingTracks(
       databaseWrapper.getTracksDB(),
-      sessionsService
+      sessionsService,
+      serverClock
     );
   }
 

--- a/apps/rpg-maestro/src/app/PlayersController.ts
+++ b/apps/rpg-maestro/src/app/PlayersController.ts
@@ -1,11 +1,42 @@
-import { Controller, Get, HttpException, HttpStatus, Inject, Param } from '@nestjs/common';
-import { SessionPlayingTracks, Track } from '@rpg-maestro/rpg-maestro-api-contract';
+import {
+  Controller,
+  Get,
+  Header,
+  HttpException,
+  HttpStatus,
+  Inject,
+  MessageEvent,
+  Param,
+  Sse,
+} from '@nestjs/common';
+import { concat, defer, finalize, interval, map, merge, Observable, of } from 'rxjs';
+import { ServerTime, SessionPlayingTracks, Track } from '@rpg-maestro/rpg-maestro-api-contract';
 import { SessionsService } from './sessions/sessions.service';
 import { TrackService } from './maestro-api/TrackService';
+import { SessionEventsService } from './sessions/session-events.service';
+import { ServerClock } from './infrastructure/clock/server-clock';
+import { SessionStreamsRegistry } from './sessions/session-streams.registry';
+
+/**
+ * Keeps an idle stream from being dropped by whatever sits between the browser and the app: an SSE
+ * connection that says nothing for minutes looks dead to a proxy, and a track can easily play that
+ * long without changing.
+ */
+export const STREAM_HEARTBEAT_INTERVAL_MS = 20_000;
+
+/** Named events, so a client's track handler is not woken up by heartbeats. */
+export const PLAYING_TRACKS_EVENT = 'playing-tracks';
+export const HEARTBEAT_EVENT = 'heartbeat';
 
 @Controller()
 export class PlayersController {
-  constructor(@Inject(SessionsService) private sessionsService: SessionsService, @Inject(TrackService) private trackService: TrackService) {}
+  constructor(
+    @Inject(SessionsService) private sessionsService: SessionsService,
+    @Inject(TrackService) private trackService: TrackService,
+    @Inject(SessionEventsService) private sessionEvents: SessionEventsService,
+    @Inject(ServerClock) private serverClock: ServerClock,
+    @Inject(SessionStreamsRegistry) private streams: SessionStreamsRegistry
+  ) {}
 
   @Get('/migrate')
   async migrate(): Promise<string> {
@@ -17,6 +48,20 @@ export class PlayersController {
     return this.trackService.get(id);
   }
 
+  /**
+   * The clock `PlayingTrack.playTimestamp` is expressed in. Clients measure their own offset against
+   * it instead of assuming their `Date.now()` agrees with it, which it usually does not.
+   *
+   * `no-store` is load-bearing: a CDN or reverse proxy that cached this would hand every client behind
+   * it the same frozen timestamp, and each would compute an offset off by however long the entry had
+   * been sitting there — turning the fix for clock skew into a source of it.
+   */
+  @Get('/server-time')
+  @Header('Cache-Control', 'no-store')
+  getServerTime(): ServerTime {
+    return { serverTime: this.serverClock.now() };
+  }
+
   @Get('/sessions/:id/playing-tracks')
   async getSessionTracks(@Param('id') sessionId: string): Promise<SessionPlayingTracks> {
     const dbValue = await this.sessionsService.getSessionPlayingTracks(sessionId);
@@ -24,5 +69,37 @@ export class PlayersController {
       throw new HttpException(`Session '${sessionId}' not found`, HttpStatus.NOT_FOUND);
     }
     return dbValue;
+  }
+
+  /**
+   * Pushes this session's playing tracks as they change, so listeners do not have to poll for them.
+   *
+   * SSE rather than a WebSocket: everything here flows server→client, so a duplex protocol would buy
+   * nothing, and a plain GET needs no sticky sessions — any instance can serve any listener, given the
+   * pub/sub fanout behind {@link SessionEventsService}.
+   *
+   * The stream opens with the current state, so a client needs no separate fetch to get started.
+   */
+  @Sse('/sessions/:id/playing-tracks/stream')
+  async streamSessionTracks(@Param('id') sessionId: string): Promise<Observable<MessageEvent>> {
+    const session = await this.sessionsService.getSessionPlayingTracks(sessionId);
+    if (!session) {
+      // Reported before the stream opens, so the client gets a 404 instead of an empty stream it would
+      // reconnect to forever.
+      throw new HttpException(`Session '${sessionId}' not found`, HttpStatus.NOT_FOUND);
+    }
+    const snapshotThenChanges: Observable<MessageEvent> = concat(
+      of(session),
+      this.sessionEvents.observe(sessionId)
+    ).pipe(map((tracks) => ({ data: tracks, type: PLAYING_TRACKS_EVENT })));
+    const heartbeats: Observable<MessageEvent> = interval(STREAM_HEARTBEAT_INTERVAL_MS).pipe(
+      map(() => ({ data: {}, type: HEARTBEAT_EVENT }))
+    );
+    // `defer` so the stream is counted when it is actually subscribed to, and `finalize` so it is
+    // uncounted however it ends — client navigating away, proxy timeout, or shutdown.
+    return defer(() => {
+      this.streams.opened(sessionId);
+      return merge(snapshotThenChanges, heartbeats);
+    }).pipe(finalize(() => this.streams.closed(sessionId)));
   }
 }

--- a/apps/rpg-maestro/src/app/app.module.ts
+++ b/apps/rpg-maestro/src/app/app.module.ts
@@ -5,6 +5,7 @@ import { join } from 'path';
 import { AuthenticatedMaestroController } from './AuthenticatedMaestroController';
 import { PlayersController } from './PlayersController';
 import { DatabaseModule } from './infrastructure/database.module';
+import { ClockModule } from './infrastructure/clock/clock.module';
 import { MaestroApiModule } from './maestro-api/maestro-api.module';
 import { HealthModule } from './health.module';
 import { NetworkingConfiguration } from './NetworkingConfiguration';
@@ -22,6 +23,7 @@ import { TestsUtilsModule } from './test-utils/tests-utils.module';
       serveRoot: '/public',
       serveStaticOptions: { redirect: false },
     }),
+    ClockModule,
     DatabaseModule,
     MaestroApiModule,
     TrackCollectionModule,

--- a/apps/rpg-maestro/src/app/health.controller.ts
+++ b/apps/rpg-maestro/src/app/health.controller.ts
@@ -1,18 +1,40 @@
 import { Controller, Get, Inject } from '@nestjs/common';
-import { HealthCheckService, HttpHealthIndicator, HealthCheck } from '@nestjs/terminus';
+import { HealthCheckService, HttpHealthIndicator, HealthCheck, HealthIndicatorResult } from '@nestjs/terminus';
 import { AppVersion } from '@rpg-maestro/rpg-maestro-api-contract';
+import { ServerClock } from './infrastructure/clock/server-clock';
+import { SessionStreamsRegistry } from './sessions/session-streams.registry';
 
 @Controller('health')
 export class HealthController {
   constructor(
     @Inject(HealthCheckService) private health: HealthCheckService,
     @Inject(HttpHealthIndicator) private http: HttpHealthIndicator,
+    @Inject(ServerClock) private serverClock: ServerClock,
+    @Inject(SessionStreamsRegistry) private streams: SessionStreamsRegistry
   ) {}
 
   @Get()
   @HealthCheck()
   check() {
-    return this.health.check([]);
+    return this.health.check([() => this.playback()]);
+  }
+
+  /**
+   * Diagnostics for the two things that make playback sound wrong without anything reporting a failure:
+   * this instance's clock drifting from the shared reference, and how many streams it is holding.
+   *
+   * Deliberately always `up`. A skewed clock or a busy instance is something to go look at, not a
+   * reason to pull a pod that is otherwise serving music out of rotation.
+   */
+  private async playback(): Promise<HealthIndicatorResult> {
+    return {
+      playback: {
+        status: 'up',
+        clockReference: this.serverClock.getReferenceName() ?? 'local',
+        clockOffsetMs: this.serverClock.getOffsetMs(),
+        openStreams: this.streams.openCount,
+      },
+    };
   }
 
   @Get('version')

--- a/apps/rpg-maestro/src/app/health.e2e.spec.ts
+++ b/apps/rpg-maestro/src/app/health.e2e.spec.ts
@@ -20,11 +20,18 @@ describe('testing healthcheck respond ok and 200', () => {
   });
 
   it(`GET: /health`, () => {
+    const playback = {
+      status: 'up',
+      // no shared redis in tests, so the local clock is the authority and there is nothing to correct
+      clockReference: 'local',
+      clockOffsetMs: 0,
+      openStreams: 0,
+    };
     return request(app.getHttpServer()).get('/health').expect(200).expect({
       status: 'ok',
-      info: {},
+      info: { playback },
       error: {},
-      details: {},
+      details: { playback },
     });
   });
 

--- a/apps/rpg-maestro/src/app/health.module.ts
+++ b/apps/rpg-maestro/src/app/health.module.ts
@@ -1,9 +1,10 @@
 import { Module } from '@nestjs/common';
 import { TerminusModule } from '@nestjs/terminus';
 import { HealthController } from './health.controller';
+import { SessionModule } from './sessions/sessions.module';
 
 @Module({
-  imports: [TerminusModule],
+  imports: [TerminusModule, SessionModule],
   controllers: [HealthController],
 })
 export class HealthModule {}

--- a/apps/rpg-maestro/src/app/infrastructure/clock/clock.module.ts
+++ b/apps/rpg-maestro/src/app/infrastructure/clock/clock.module.ts
@@ -1,0 +1,28 @@
+import { Global, Logger, Module } from '@nestjs/common';
+import { sharedRedisUrl } from '../redis/redis-connection';
+import { RedisTimeReference } from './redis-time-reference';
+import { ServerClock, TIME_REFERENCE } from './server-clock';
+import { TimeReference } from './time-reference';
+
+const logger = new Logger('ClockModule');
+
+export function createTimeReference(): TimeReference | null {
+  const url = sharedRedisUrl();
+  if (!url) {
+    logger.log('no shared redis configured, the local clock is the playback time authority');
+    return null;
+  }
+  return new RedisTimeReference(url);
+}
+
+/**
+ * Global on purpose: every write path that stamps a playback timestamp needs the same clock, and
+ * threading it through each module that happens to build a `ManageCurrentlyPlayingTracks` would
+ * only spread the wiring without adding a decision anywhere.
+ */
+@Global()
+@Module({
+  providers: [ServerClock, { provide: TIME_REFERENCE, useFactory: createTimeReference }],
+  exports: [ServerClock],
+})
+export class ClockModule {}

--- a/apps/rpg-maestro/src/app/infrastructure/clock/redis-time-reference.ts
+++ b/apps/rpg-maestro/src/app/infrastructure/clock/redis-time-reference.ts
@@ -1,0 +1,55 @@
+import { Logger } from '@nestjs/common';
+import { createRedisConnection, RedisConnection } from '../redis/redis-connection';
+import { TimeReference } from './time-reference';
+
+/**
+ * Redis' own clock, read with `TIME`, as the instant every instance agrees on.
+ *
+ * Redis is already the one piece of infrastructure all instances share, which is what makes it a
+ * usable reference: it is a single clock, reachable in a millisecond or two, and it does not need a
+ * write to be read — unlike a database server timestamp, which would cost a round trip *and* a write
+ * on every track change.
+ */
+export class RedisTimeReference implements TimeReference {
+  readonly name = 'redis';
+  private readonly logger = new Logger(RedisTimeReference.name);
+  private readonly client: RedisConnection;
+  private connecting: Promise<void> | null = null;
+
+  constructor(url: string) {
+    this.client = createRedisConnection(url, this.name);
+  }
+
+  async read(): Promise<number> {
+    await this.connect();
+    const [seconds, microseconds] = await this.client.time();
+    return Number(seconds) * 1000 + Number(microseconds) / 1000;
+  }
+
+  async close(): Promise<void> {
+    if (this.client.isOpen) {
+      await this.client.close();
+    }
+  }
+
+  /**
+   * Connects on first use, and lets a failed attempt be retried by the next one: the clock resyncs
+   * on a loop, so a Redis that is down at boot only costs the accuracy of the offset until it is back.
+   */
+  private async connect(): Promise<void> {
+    if (this.client.isReady) {
+      return;
+    }
+    if (!this.connecting) {
+      this.connecting = this.client
+        .connect()
+        .then(() => {
+          this.logger.log('connected to the redis time reference');
+        })
+        .finally(() => {
+          this.connecting = null;
+        });
+    }
+    await this.connecting;
+  }
+}

--- a/apps/rpg-maestro/src/app/infrastructure/clock/server-clock.spec.ts
+++ b/apps/rpg-maestro/src/app/infrastructure/clock/server-clock.spec.ts
@@ -1,0 +1,85 @@
+import { bestOffset, ClockSample, measureOffset, ServerClock } from './server-clock';
+import { TimeReference } from './time-reference';
+
+class FakeTimeReference implements TimeReference {
+  readonly name = 'fake';
+  reads = 0;
+
+  constructor(private readonly behaviour: (read: number) => number) {}
+
+  async read(): Promise<number> {
+    this.reads++;
+    return this.behaviour(this.reads);
+  }
+
+  async close(): Promise<void> {
+    // nothing to close
+  }
+}
+
+describe('measureOffset', () => {
+  it('assumes the reference was read halfway through the round trip', () => {
+    const sample: ClockSample = { localSentAt: 1000, referenceTime: 5100, localReceivedAt: 1200 };
+
+    // reference read at local 1100 (the midpoint) while it said 5100, so we are 4000ms behind it
+    expect(measureOffset(sample)).toEqual({ offsetMs: 4000, roundTripMs: 200 });
+  });
+
+  it('reports no offset when the reference agrees with the local clock', () => {
+    const sample: ClockSample = { localSentAt: 1000, referenceTime: 1050, localReceivedAt: 1100 };
+
+    expect(measureOffset(sample)).toEqual({ offsetMs: 0, roundTripMs: 100 });
+  });
+});
+
+describe('bestOffset', () => {
+  it('keeps the sample with the shortest round trip, since a slow read hides an asymmetric delay', () => {
+    const fast: ClockSample = { localSentAt: 1000, referenceTime: 1010, localReceivedAt: 1020 };
+    // a queued read, whose midpoint guess is off by the whole queueing delay
+    const slow: ClockSample = { localSentAt: 2000, referenceTime: 2010, localReceivedAt: 3000 };
+
+    expect(bestOffset([slow, fast])).toEqual({ offsetMs: 0, roundTripMs: 20 });
+  });
+
+  it('has nothing to say when no sample was taken', () => {
+    expect(bestOffset([])).toBeNull();
+  });
+});
+
+describe('ServerClock', () => {
+  it('is the local clock when no reference is configured', async () => {
+    const clock = new ServerClock(null);
+
+    await clock.resync();
+
+    expect(clock.getOffsetMs()).toBe(0);
+    expect(clock.now()).toBeCloseTo(Date.now(), -2);
+  });
+
+  it('corrects the local clock towards the reference', async () => {
+    const oneHourAhead = Date.now() + 3600_000;
+    const clock = new ServerClock(new FakeTimeReference(() => oneHourAhead));
+
+    await clock.resync();
+
+    expect(clock.getOffsetMs()).toBeGreaterThan(3599_000);
+    expect(clock.now()).toBeGreaterThan(oneHourAhead - 1000);
+  });
+
+  it('keeps the last known offset when the reference stops answering', async () => {
+    const reference = new FakeTimeReference((read) => {
+      if (read > 5) {
+        throw new Error('reference is down');
+      }
+      return Date.now() + 3600_000;
+    });
+    const clock = new ServerClock(reference);
+    await clock.resync();
+    const offsetWhileHealthy = clock.getOffsetMs();
+
+    await clock.resync();
+
+    // A stale correction is much closer to the truth than dropping back to the raw local clock.
+    expect(clock.getOffsetMs()).toBe(offsetWhileHealthy);
+  });
+});

--- a/apps/rpg-maestro/src/app/infrastructure/clock/server-clock.ts
+++ b/apps/rpg-maestro/src/app/infrastructure/clock/server-clock.ts
@@ -1,0 +1,149 @@
+import { Inject, Injectable, Logger, OnApplicationBootstrap, OnModuleDestroy, Optional } from '@nestjs/common';
+import ms from 'ms';
+import { TimeReference } from './time-reference';
+
+export const TIME_REFERENCE = 'TIME_REFERENCE';
+
+/** How often the local offset against the reference is measured again. */
+export const RESYNC_INTERVAL_MS = ms('30s');
+
+/** Reads per measurement. The one with the shortest round trip wins, see {@link bestOffset}. */
+export const SAMPLES_PER_RESYNC = 5;
+
+/** Above this, the local clock is off by enough to be audible, so it is worth a log line. */
+export const NOTEWORTHY_OFFSET_MS = 250;
+
+export interface ClockSample {
+  /** Local epoch ms just before the read was issued. */
+  localSentAt: number;
+  /** What the reference answered. */
+  referenceTime: number;
+  /** Local epoch ms just after the answer came back. */
+  localReceivedAt: number;
+}
+
+export interface ClockMeasurement {
+  /** Add this to `Date.now()` to get the reference's time. */
+  offsetMs: number;
+  roundTripMs: number;
+}
+
+/**
+ * NTP's estimator, with the two timestamps the reference does not give us folded away: the reference
+ * read happened somewhere inside our round trip, and the midpoint is the least-wrong guess.
+ */
+export function measureOffset(sample: ClockSample): ClockMeasurement {
+  const roundTripMs = sample.localReceivedAt - sample.localSentAt;
+  return {
+    offsetMs: sample.referenceTime + roundTripMs / 2 - sample.localReceivedAt,
+    roundTripMs,
+  };
+}
+
+/**
+ * The shortest round trip, not the average: a slow read is slow because something queued, and
+ * queueing is asymmetric, which is exactly what the midpoint guess above cannot model. Averaging
+ * would fold that error in instead of discarding it.
+ */
+export function bestOffset(samples: ClockSample[]): ClockMeasurement | null {
+  return samples
+    .map(measureOffset)
+    .reduce<ClockMeasurement | null>((best, m) => (best === null || m.roundTripMs < best.roundTripMs ? m : best), null);
+}
+
+/**
+ * The clock every playback timestamp is expressed in.
+ *
+ * Instances correct their own wall clock against a single {@link TimeReference}, so a track change
+ * stamped by one pod means the same instant as one stamped by another. Without a reference
+ * configured — local dev, tests — this is `Date.now()` and the offset stays 0, which is correct
+ * there since there is only one clock in play.
+ *
+ * Clients must not compare these timestamps against their own `Date.now()`: they negotiate their own
+ * offset against `GET /server-time`, which reads this same clock.
+ */
+@Injectable()
+export class ServerClock implements OnApplicationBootstrap, OnModuleDestroy {
+  private readonly logger = new Logger(ServerClock.name);
+  private offsetMs = 0;
+  private resyncTimer: NodeJS.Timeout | null = null;
+
+  constructor(@Optional() @Inject(TIME_REFERENCE) private readonly reference: TimeReference | null) {}
+
+  /** Epoch ms on the shared clock. */
+  now(): number {
+    return Date.now() + this.offsetMs;
+  }
+
+  getOffsetMs(): number {
+    return this.offsetMs;
+  }
+
+  /** Name of the shared clock being followed, or `null` when the local clock is the authority. */
+  getReferenceName(): string | null {
+    return this.reference?.name ?? null;
+  }
+
+  async onApplicationBootstrap(): Promise<void> {
+    if (!this.reference) {
+      this.logger.log('no time reference configured, playback timestamps use the local clock');
+      return;
+    }
+    this.logger.log(`using "${this.reference.name}" as the time reference for playback timestamps`);
+    await this.resync();
+    this.resyncTimer = setInterval(() => {
+      this.resync().catch((error) => this.logger.warn('clock resync threw', error));
+    }, RESYNC_INTERVAL_MS);
+    // Nothing should be kept alive by a clock: without this, a failing e2e run or test suite hangs
+    // on an open handle instead of exiting.
+    this.resyncTimer.unref();
+  }
+
+  async onModuleDestroy(): Promise<void> {
+    if (this.resyncTimer) {
+      clearInterval(this.resyncTimer);
+      this.resyncTimer = null;
+    }
+    await this.reference?.close();
+  }
+
+  /**
+   * Measures the offset again. A failure keeps the last known offset: a stale correction is much
+   * closer to the truth than dropping back to the raw local clock, and the reference being
+   * unreachable is not a reason to stop serving music.
+   */
+  async resync(): Promise<void> {
+    if (!this.reference) {
+      return;
+    }
+    const samples: ClockSample[] = [];
+    for (let i = 0; i < SAMPLES_PER_RESYNC; i++) {
+      try {
+        const localSentAt = Date.now();
+        const referenceTime = await this.reference.read();
+        samples.push({ localSentAt, referenceTime, localReceivedAt: Date.now() });
+      } catch (error) {
+        this.logger.warn(`time reference "${this.reference.name}" could not be read`, error);
+        break;
+      }
+    }
+    const measurement = bestOffset(samples);
+    if (!measurement) {
+      this.logger.warn(
+        `time reference "${this.reference.name}" is unreachable, keeping the last known offset of ${this.offsetMs}ms`
+      );
+      return;
+    }
+    const previousOffsetMs = this.offsetMs;
+    this.offsetMs = Math.round(measurement.offsetMs);
+    if (
+      Math.abs(this.offsetMs) >= NOTEWORTHY_OFFSET_MS ||
+      Math.abs(this.offsetMs - previousOffsetMs) >= NOTEWORTHY_OFFSET_MS
+    ) {
+      this.logger.log(
+        `local clock is ${this.offsetMs}ms off "${this.reference.name}" (was ${previousOffsetMs}ms), ` +
+          `round trip ${measurement.roundTripMs}ms`
+      );
+    }
+  }
+}

--- a/apps/rpg-maestro/src/app/infrastructure/clock/time-reference.ts
+++ b/apps/rpg-maestro/src/app/infrastructure/clock/time-reference.ts
@@ -1,0 +1,17 @@
+/**
+ * A clock shared by every instance of the app, used to correct the local wall clock.
+ *
+ * Playback positions are reconstructed from `PlayingTrack.playTimestamp`, so that timestamp must
+ * mean the same thing whichever pod stamped it. `Date.now()` does not qualify: two pods drift apart
+ * by whatever their hosts' NTP daemons allow, and that drift lands straight on the playhead every
+ * listener computes.
+ */
+export interface TimeReference {
+  /** Used in logs only. */
+  readonly name: string;
+
+  /** Epoch ms according to the reference, read at the moment of the call. */
+  read(): Promise<number>;
+
+  close(): Promise<void>;
+}

--- a/apps/rpg-maestro/src/app/infrastructure/redis/redis-connection.ts
+++ b/apps/rpg-maestro/src/app/infrastructure/redis/redis-connection.ts
@@ -1,0 +1,37 @@
+import { Logger } from '@nestjs/common';
+import { createClient } from '@redis/client';
+
+const logger = new Logger('Redis');
+
+/**
+ * The Redis every instance of the app shares, or `null` when there is none — local dev and the e2e
+ * tests run a single instance, where the local clock and an in-process event bus are already
+ * consistent.
+ *
+ * The primary is preferred and the managed fallback is used when it is the only one configured, which
+ * mirrors the priority order of the cache tiers (`infrastructure/cache/cache-tiers.factory.ts`).
+ * Unlike the cache this does not fail over between the two at runtime: both the clock and the event
+ * fanout only work if *every* instance picked the same one, and instances cannot agree on a switch.
+ */
+export function sharedRedisUrl(): string | null {
+  return process.env.CACHE_REDIS_URL ?? process.env.CACHE_FALLBACK_REDIS_URL ?? null;
+}
+
+/**
+ * A client that is not connected yet. Callers connect it themselves, so that a Redis that is down at
+ * boot delays the feature that needs it rather than the whole app.
+ *
+ * The 'error' listener is not optional: node-redis emits connection failures as events, and an
+ * unhandled 'error' event takes the process down.
+ */
+export function createRedisConnection(url: string, name: string) {
+  const client = createClient({ url });
+  client.on('error', (error) => logger.warn(`redis connection "${name}" emitted an error`, error));
+  return client;
+}
+
+/**
+ * Inferred from the factory rather than spelled out: `RedisClientType`'s generics default to a RESP 2
+ * client, which is not what `createClient` returns, and naming the mismatch is not worth the noise.
+ */
+export type RedisConnection = ReturnType<typeof createRedisConnection>;

--- a/apps/rpg-maestro/src/app/maestro-api/MaestroAPI.spec.ts
+++ b/apps/rpg-maestro/src/app/maestro-api/MaestroAPI.spec.ts
@@ -11,6 +11,9 @@ import {
   TrackCreationFromYoutubeJobsWatcher
 } from '../track-creation-from-youtube-jobs-watcher/track-creation-from-youtube-jobs-watcher.service';
 import { SessionsService } from '../sessions/sessions.service';
+import { SessionEventsService } from '../sessions/session-events.service';
+import { InProcessSessionEventsBroker } from '../sessions/session-events.broker';
+import { ServerClock } from '../infrastructure/clock/server-clock';
 
 let createTrack: TrackService;
 let manageCurrentlyPlayingTracks: ManageCurrentlyPlayingTracks;
@@ -25,14 +28,14 @@ const CURRENT_DATE = Date.now();
 beforeAll(() => {
   const databases = new DatabaseWrapperConfiguration('in-memory');
   database = databases.getTracksDB();
-  const sessionsService = new SessionsService(databases);
+  const sessionsService = new SessionsService(databases, new SessionEventsService(new InProcessSessionEventsBroker()));
   createTrack = new TrackService(
     databases,
     new InMemoryTrackCreationFromYoutubeJobsStore(),
     null as TrackCreationFromYoutubeJobsWatcher,
     null as AudioFileUploaderClient
   );
-  manageCurrentlyPlayingTracks = new ManageCurrentlyPlayingTracks(database, sessionsService);
+  manageCurrentlyPlayingTracks = new ManageCurrentlyPlayingTracks(database, sessionsService, new ServerClock(null));
 
 
   app.use('/public', express.static(path.join(__dirname, '../../assets')));

--- a/apps/rpg-maestro/src/app/maestro-api/ManageCurrentlyPlayingTracks.ts
+++ b/apps/rpg-maestro/src/app/maestro-api/ManageCurrentlyPlayingTracks.ts
@@ -5,14 +5,17 @@ import {
   SessionPlayingTracks,
 } from '@rpg-maestro/rpg-maestro-api-contract';
 import { SessionsService } from '../sessions/sessions.service';
+import { ServerClock } from '../infrastructure/clock/server-clock';
 
 export class ManageCurrentlyPlayingTracks {
   database: TracksDatabase;
   sessionsService: SessionsService;
+  serverClock: ServerClock;
 
-  constructor(database: TracksDatabase, sessionsService: SessionsService) {
+  constructor(database: TracksDatabase, sessionsService: SessionsService, serverClock: ServerClock) {
     this.database = database;
     this.sessionsService = sessionsService;
+    this.serverClock = serverClock;
   }
 
   async changeSessionPlayingTracks(
@@ -34,7 +37,7 @@ export class ManageCurrentlyPlayingTracks {
         track.url,
         track.duration,
         false,
-        Date.now(),
+        this.serverClock.now(),
         0
       );
       return this.sessionsService.upsertShortEffectTrack(sessionId, playingTrack);
@@ -51,7 +54,7 @@ export class ManageCurrentlyPlayingTracks {
       track.url,
       track.duration,
       changeSessionPlayingTracksRequest.currentTrack.paused ?? false,
-      Date.now(),
+      this.serverClock.now(),
       changeSessionPlayingTracksRequest.currentTrack.startTime ?? 0
     );
     return this.sessionsService.upsertCurrentTrack(sessionId, playingTrack);

--- a/apps/rpg-maestro/src/app/maestro-api/onboarding.service.ts
+++ b/apps/rpg-maestro/src/app/maestro-api/onboarding.service.ts
@@ -15,6 +15,7 @@ import { TrackCollectionService } from '../track-collection/track-collection.ser
 import { ManageCurrentlyPlayingTracks } from './ManageCurrentlyPlayingTracks';
 import { UsersService } from '../users-management/users.service';
 import { SessionsService } from '../sessions/sessions.service';
+import { ServerClock } from '../infrastructure/clock/server-clock';
 
 @Injectable()
 export class OnboardingService {
@@ -25,11 +26,13 @@ export class OnboardingService {
     @Inject(SessionsService) private sessionsService: SessionsService,
     @Inject(TrackService) private trackService: TrackService,
     @Inject(TrackCollectionService) private trackCollectionService: TrackCollectionService,
-    @Inject(UsersService) private usersService: UsersService
+    @Inject(UsersService) private usersService: UsersService,
+    @Inject(ServerClock) serverClock: ServerClock
   ) {
     this.manageCurrentlyPlayingTracks = new ManageCurrentlyPlayingTracks(
       databaseWrapper.getTracksDB(),
-      sessionsService
+      sessionsService,
+      serverClock
     );
   }
 

--- a/apps/rpg-maestro/src/app/maestro-api/onboarding.spec.ts
+++ b/apps/rpg-maestro/src/app/maestro-api/onboarding.spec.ts
@@ -10,6 +10,9 @@ import { AudioFileUploaderClient } from '../track-creation-from-youtube-jobs-wat
 import { TrackCollectionService } from '../track-collection/track-collection.service';
 import { UsersService } from '../users-management/users.service';
 import { SessionsService } from '../sessions/sessions.service';
+import { SessionEventsService } from '../sessions/session-events.service';
+import { InProcessSessionEventsBroker } from '../sessions/session-events.broker';
+import { ServerClock } from '../infrastructure/clock/server-clock';
 
 let onboardingService: OnboardingService;
 let databases: DatabaseWrapperConfiguration;
@@ -26,7 +29,7 @@ beforeAll(async () => {
 });
 beforeEach(() => {
   databases = new DatabaseWrapperConfiguration('in-memory');
-  const sessionsService = new SessionsService(databases);
+  const sessionsService = new SessionsService(databases, new SessionEventsService(new InProcessSessionEventsBroker()));
   onboardingService = new OnboardingService(
     databases,
     sessionsService,
@@ -37,7 +40,8 @@ beforeEach(() => {
       null as AudioFileUploaderClient
     ),
     new TrackCollectionService(databases, sessionsService),
-    new UsersService(databases)
+    new UsersService(databases),
+    new ServerClock(null)
   );
 });
 

--- a/apps/rpg-maestro/src/app/players.e2e.spec.ts
+++ b/apps/rpg-maestro/src/app/players.e2e.spec.ts
@@ -1,0 +1,162 @@
+process.env.DATABASE = 'in-memory';
+process.env.DEFAULT_AUDIO_FILE_UPLOADER_API_URL = 'http://localhost:8098/not-used-in-this-test';
+process.env.DEFAULT_FRONTEND_DOMAIN = 'http://localhost:4300/not-used-in-this-test';
+process.env.PORT = '3017';
+process.env.NODE_ENV = 'unit-tests';
+process.env.CONFIGURATION_ENV = 'unit-tests';
+process.env.LOG_LEVEL = 'WARN';
+
+import { INestApplication } from '@nestjs/common';
+import request from 'supertest';
+import { PlayingTrack, ServerTime, SessionPlayingTracks } from '@rpg-maestro/rpg-maestro-api-contract';
+import { TestUsersFixture } from '@rpg-maestro/test-utils';
+import { SessionsService } from './sessions/sessions.service';
+
+const BASE_URL = 'http://localhost:3017';
+
+describe('Players API', () => {
+  let app: INestApplication;
+  let sessionId: string;
+
+  beforeAll(async () => {
+    process.env.AUTH_ISSUER = `${BASE_URL}/test-utils/fake-idp`;
+    process.env.AUTH_JWT_AUDIENCE = BASE_URL;
+    const { bootstrap } = await import('./../app-bootstrap');
+    app = await bootstrap();
+    const users = await request(app.getHttpServer())
+      .post('/test-utils/create-test-users-fixtures')
+      .expect(201)
+      .then((httpResponse) => httpResponse.body as TestUsersFixture);
+    const session = await request(app.getHttpServer())
+      .post('/maestro/sessions')
+      .set('Authorization', `Bearer ${users.a_maestro_user.token}`)
+      .send({})
+      .then((httpResponse) => httpResponse.body as SessionPlayingTracks);
+    sessionId = session.sessionId;
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  it('GET /server-time answers with the clock playback timestamps are stamped in, uncacheably', async () => {
+    const before = Date.now();
+    const { serverTime } = await request(app.getHttpServer())
+      .get('/server-time')
+      .expect(200)
+      // A cached timestamp would hand everyone behind that cache the same stale instant, so every one
+      // of them would measure an offset off by however long the entry had been sitting there.
+      .expect('Cache-Control', 'no-store')
+      .then((httpResponse) => httpResponse.body as ServerTime);
+
+    expect(serverTime).toBeGreaterThanOrEqual(before - 1000);
+    expect(serverTime).toBeLessThanOrEqual(Date.now() + 1000);
+  });
+
+  it('the playing-tracks stream opens with the current state and then pushes every change', async () => {
+    const stream = await openStream(`${BASE_URL}/sessions/${sessionId}/playing-tracks/stream`);
+    try {
+      const snapshot = await stream.nextEvent();
+      expect(snapshot.type).toBe('playing-tracks');
+      expect((snapshot.data as SessionPlayingTracks).sessionId).toBe(sessionId);
+      expect((snapshot.data as SessionPlayingTracks).currentTrack).toBeFalsy();
+
+      // Through the service the Maestro's write path goes through, so this covers the publish that
+      // happens on a real track change without needing an uploaded audio file.
+      await app
+        .get(SessionsService)
+        .upsertCurrentTrack(
+          sessionId,
+          new PlayingTrack('track-1', 'a-pushed-track', 'http://localhost/track.mp3', 120000, false, Date.now(), 0)
+        );
+
+      const pushed = await stream.nextEvent();
+      expect(pushed.type).toBe('playing-tracks');
+      expect((pushed.data as SessionPlayingTracks).currentTrack?.name).toBe('a-pushed-track');
+    } finally {
+      await stream.close();
+    }
+  }, 10000);
+
+  it('reports its open streams on /health, since a stream holds a connection for as long as a listener stays', async () => {
+    const openStreams = async (): Promise<number> => {
+      const body = await request(app.getHttpServer())
+        .get('/health')
+        .then((httpResponse) => httpResponse.body as { details: { playback: { openStreams: number } } });
+      return body.details.playback.openStreams;
+    };
+    expect(await openStreams()).toBe(0);
+
+    const stream = await openStream(`${BASE_URL}/sessions/${sessionId}/playing-tracks/stream`);
+    await stream.nextEvent();
+    expect(await openStreams()).toBe(1);
+
+    await stream.close();
+    // the count comes back down however the stream ended, here a client hanging up
+    await expect.poll(() => openStreams()).toBe(0);
+  }, 10000);
+
+  it('a stream for a session that does not exist is refused, instead of hanging open', async () => {
+    // The client can then stop retrying, rather than reconnecting forever to a stream that will never
+    // say anything.
+    await request(app.getHttpServer()).get('/sessions/no-such-session/playing-tracks/stream').expect(404);
+  });
+});
+
+interface ServerSentEvent {
+  type: string;
+  data: unknown;
+}
+
+/**
+ * Minimal SSE client: supertest buffers a response until it ends, which a stream never does, so this
+ * reads the body as it arrives and hands out one parsed event at a time.
+ */
+async function openStream(url: string): Promise<{ nextEvent: () => Promise<ServerSentEvent>; close: () => Promise<void> }> {
+  const abort = new AbortController();
+  const response = await fetch(url, { headers: { Accept: 'text/event-stream' }, signal: abort.signal });
+  if (!response.ok || !response.body) {
+    throw new Error(`could not open the stream: ${response.status}`);
+  }
+  const reader = response.body.getReader();
+  const decoder = new TextDecoder();
+  let buffered = '';
+
+  const nextEvent = async (): Promise<ServerSentEvent> => {
+    for (;;) {
+      const separator = buffered.indexOf('\n\n');
+      if (separator >= 0) {
+        const raw = buffered.slice(0, separator);
+        buffered = buffered.slice(separator + 2);
+        const event = parseEvent(raw);
+        if (event) {
+          return event;
+        }
+        continue;
+      }
+      const { done, value } = await reader.read();
+      if (done) {
+        throw new Error('the stream ended before the expected event');
+      }
+      buffered += decoder.decode(value, { stream: true });
+    }
+  };
+
+  return {
+    nextEvent,
+    close: async () => {
+      abort.abort();
+      await reader.cancel().catch(() => undefined);
+    },
+  };
+}
+
+function parseEvent(raw: string): ServerSentEvent | null {
+  const lines = raw.split('\n');
+  const type = lines.find((line) => line.startsWith('event:'))?.slice('event:'.length).trim();
+  const data = lines.find((line) => line.startsWith('data:'))?.slice('data:'.length).trim();
+  if (!type || !data) {
+    return null;
+  }
+  return { type, data: JSON.parse(data) };
+}

--- a/apps/rpg-maestro/src/app/sessions/redis-session-events.broker.ts
+++ b/apps/rpg-maestro/src/app/sessions/redis-session-events.broker.ts
@@ -1,0 +1,106 @@
+import { Logger } from '@nestjs/common';
+import ms from 'ms';
+import { SessionPlayingTracks } from '@rpg-maestro/rpg-maestro-api-contract';
+import { createRedisConnection, RedisConnection } from '../infrastructure/redis/redis-connection';
+import { SessionEventsBroker, SessionEventsListener } from './session-events.broker';
+
+/**
+ * One channel for every session. Track changes happen a few times per session per hour, so splitting
+ * them per session would buy nothing but a subscribe/unsubscribe dance on every stream open and close.
+ * Instances filter by session id on receipt.
+ */
+export const SESSION_EVENTS_CHANNEL = 'rpg-maestro:session-playing-tracks';
+
+/** How long before a failed subscribe is attempted again. */
+export const SUBSCRIBE_RETRY_INTERVAL_MS = ms('5s');
+
+/**
+ * Redis pub/sub fanout, so a Maestro's track change reaches listeners connected to any instance.
+ *
+ * Losing it degrades rather than breaks: clients keep a slow poll running as a safety net, so a
+ * dropped event costs latency, not correctness. That is why nothing here throws at the caller — a
+ * failed publish is logged and the write it belongs to still stands.
+ */
+export class RedisSessionEventsBroker implements SessionEventsBroker {
+  readonly name = 'redis';
+  private readonly logger = new Logger(RedisSessionEventsBroker.name);
+  private readonly publisher: RedisConnection;
+  private readonly subscriber: RedisConnection;
+  private listener: SessionEventsListener | null = null;
+  private retryTimer: NodeJS.Timeout | null = null;
+  private closed = false;
+
+  constructor(url: string) {
+    this.publisher = createRedisConnection(url, 'session-events-publisher');
+    // Subscribing puts a connection in a mode where it cannot run normal commands, hence the second one.
+    this.subscriber = createRedisConnection(url, 'session-events-subscriber');
+  }
+
+  async publish(session: SessionPlayingTracks): Promise<void> {
+    try {
+      if (!this.publisher.isReady) {
+        await this.publisher.connect();
+      }
+      await this.publisher.publish(SESSION_EVENTS_CHANNEL, JSON.stringify(session));
+    } catch (error) {
+      this.logger.warn(
+        `could not publish the change of session "${session.sessionId}", listeners will pick it up on their next poll`,
+        error
+      );
+    }
+  }
+
+  async subscribe(listener: SessionEventsListener): Promise<void> {
+    this.listener = listener;
+    await this.connectSubscriber();
+  }
+
+  async close(): Promise<void> {
+    this.closed = true;
+    if (this.retryTimer) {
+      clearTimeout(this.retryTimer);
+      this.retryTimer = null;
+    }
+    this.listener = null;
+    await Promise.all([
+      this.publisher.isOpen ? this.publisher.close() : Promise.resolve(),
+      this.subscriber.isOpen ? this.subscriber.close() : Promise.resolve(),
+    ]);
+  }
+
+  /**
+   * node-redis re-subscribes on its own once a connection it had established drops, so retrying is
+   * only about the first connection: a Redis that is down at boot must not stop the app from serving
+   * music, nor leave it permanently deaf once Redis is back.
+   */
+  private async connectSubscriber(): Promise<void> {
+    if (this.closed) {
+      return;
+    }
+    try {
+      await this.subscriber.connect();
+      await this.subscriber.subscribe(SESSION_EVENTS_CHANNEL, (message) => this.onMessage(message));
+      this.logger.log(`subscribed to "${SESSION_EVENTS_CHANNEL}", session changes fan out across instances`);
+    } catch (error) {
+      this.logger.warn(
+        `could not subscribe to "${SESSION_EVENTS_CHANNEL}", retrying in ${SUBSCRIBE_RETRY_INTERVAL_MS}ms — ` +
+          `until then, listeners on this instance rely on their fallback poll`,
+        error
+      );
+      this.retryTimer = setTimeout(() => {
+        this.connectSubscriber().catch((retryError) => this.logger.warn('subscribe retry threw', retryError));
+      }, SUBSCRIBE_RETRY_INTERVAL_MS);
+      this.retryTimer.unref();
+    }
+  }
+
+  private onMessage(message: string): void {
+    try {
+      // Plain data, not a PlayingTrack instance: nothing on the server side calls its methods, and it
+      // is serialized again on its way out to the client.
+      this.listener?.(JSON.parse(message) as SessionPlayingTracks);
+    } catch (error) {
+      this.logger.warn(`dropping an unparseable session event: ${message}`, error);
+    }
+  }
+}

--- a/apps/rpg-maestro/src/app/sessions/session-events.broker.ts
+++ b/apps/rpg-maestro/src/app/sessions/session-events.broker.ts
@@ -1,0 +1,48 @@
+import { Logger } from '@nestjs/common';
+import { SessionPlayingTracks } from '@rpg-maestro/rpg-maestro-api-contract';
+
+export type SessionEventsListener = (session: SessionPlayingTracks) => void;
+
+/**
+ * Carries "this session's playing tracks changed" from the instance that handled the Maestro's write
+ * to the instances holding the listeners' streams.
+ *
+ * The Maestro and the audience do not land on the same instance, so an in-process event bus is only
+ * enough while there is a single instance. A broker delivers to **every** subscriber, including the
+ * one on the publishing instance, so callers never have to special-case their own events.
+ */
+export interface SessionEventsBroker {
+  /** Used in logs only. */
+  readonly name: string;
+
+  publish(session: SessionPlayingTracks): Promise<void>;
+
+  /** Registers the single listener that feeds this instance's streams. */
+  subscribe(listener: SessionEventsListener): Promise<void>;
+
+  close(): Promise<void>;
+}
+
+/**
+ * Delivers events inside one process. Correct for local dev and the e2e tests, where there is only
+ * one instance, and a silent lie as soon as there are two — which is why production configures the
+ * Redis broker instead.
+ */
+export class InProcessSessionEventsBroker implements SessionEventsBroker {
+  readonly name = 'in-process';
+  private readonly logger = new Logger(InProcessSessionEventsBroker.name);
+  private listener: SessionEventsListener | null = null;
+
+  async publish(session: SessionPlayingTracks): Promise<void> {
+    this.listener?.(session);
+  }
+
+  async subscribe(listener: SessionEventsListener): Promise<void> {
+    this.logger.log('session events are delivered in-process, this only works with a single instance');
+    this.listener = listener;
+  }
+
+  async close(): Promise<void> {
+    this.listener = null;
+  }
+}

--- a/apps/rpg-maestro/src/app/sessions/session-events.service.spec.ts
+++ b/apps/rpg-maestro/src/app/sessions/session-events.service.spec.ts
@@ -1,0 +1,51 @@
+import { firstValueFrom, toArray } from 'rxjs';
+import { PlayingTrack, SessionPlayingTracks } from '@rpg-maestro/rpg-maestro-api-contract';
+import { SessionEventsService } from './session-events.service';
+import { InProcessSessionEventsBroker, SessionEventsBroker, SessionEventsListener } from './session-events.broker';
+
+function sessionState(sessionId: string, trackId: string): SessionPlayingTracks {
+  return {
+    sessionId,
+    currentTrack: new PlayingTrack(trackId, trackId, 'url', 120000, false, 1730000000000, 0),
+    shortEffectTrack: null,
+  };
+}
+
+describe('SessionEventsService', () => {
+  it('streams the changes of the observed session', async () => {
+    const service = new SessionEventsService(new InProcessSessionEventsBroker());
+    await service.onApplicationBootstrap();
+
+    const received = firstValueFrom(service.observe('session-a'));
+    await service.publish(sessionState('session-a', 'track-1'));
+
+    expect((await received).currentTrack?.id).toBe('track-1');
+  });
+
+  it('does not leak one session changes into another session stream', async () => {
+    const service = new SessionEventsService(new InProcessSessionEventsBroker());
+    await service.onApplicationBootstrap();
+
+    const received = firstValueFrom(service.observe('session-a').pipe(toArray()));
+    await service.publish(sessionState('session-b', 'track-b'));
+    await service.publish(sessionState('session-a', 'track-a'));
+    await service.onModuleDestroy();
+
+    expect((await received).map((session) => session.currentTrack?.id)).toEqual(['track-a']);
+  });
+
+  it('does not fail the write it reports when the broker is broken', async () => {
+    const brokenBroker: SessionEventsBroker = {
+      name: 'broken',
+      publish: () => Promise.reject(new Error('pub/sub is down')),
+      subscribe: async (_listener: SessionEventsListener) => undefined,
+      close: async () => undefined,
+    };
+    const service = new SessionEventsService(brokenBroker);
+    await service.onApplicationBootstrap();
+
+    // A track change that made it to the database must not be reported as failed just because the
+    // listeners could not be told about it — they still have their fallback poll.
+    await expect(service.publish(sessionState('session-a', 'track-1'))).resolves.toBeUndefined();
+  });
+});

--- a/apps/rpg-maestro/src/app/sessions/session-events.service.ts
+++ b/apps/rpg-maestro/src/app/sessions/session-events.service.ts
@@ -1,0 +1,43 @@
+import { Inject, Injectable, Logger, OnApplicationBootstrap, OnModuleDestroy } from '@nestjs/common';
+import { filter, Observable, Subject } from 'rxjs';
+import { SessionPlayingTracks } from '@rpg-maestro/rpg-maestro-api-contract';
+import { SessionEventsBroker } from './session-events.broker';
+
+export const SESSION_EVENTS_BROKER = 'SESSION_EVENTS_BROKER';
+
+/**
+ * The push side of playback state: what the Maestro writes, streamed to the listeners of that session
+ * wherever they are connected.
+ *
+ * Events are whole snapshots rather than diffs, so a client that missed one is still correct after the
+ * next, and the fallback poll and the stream can be handled by exactly the same code on the client.
+ */
+@Injectable()
+export class SessionEventsService implements OnApplicationBootstrap, OnModuleDestroy {
+  private readonly logger = new Logger(SessionEventsService.name);
+  private readonly events = new Subject<SessionPlayingTracks>();
+
+  constructor(@Inject(SESSION_EVENTS_BROKER) private readonly broker: SessionEventsBroker) {}
+
+  async onApplicationBootstrap(): Promise<void> {
+    await this.broker.subscribe((session) => this.events.next(session));
+  }
+
+  async onModuleDestroy(): Promise<void> {
+    this.events.complete();
+    await this.broker.close();
+  }
+
+  /** Announces a change to every instance. Never throws: the write it reports already happened. */
+  async publish(session: SessionPlayingTracks): Promise<void> {
+    try {
+      await this.broker.publish(session);
+    } catch (error) {
+      this.logger.warn(`could not announce the change of session "${session.sessionId}"`, error);
+    }
+  }
+
+  observe(sessionId: string): Observable<SessionPlayingTracks> {
+    return this.events.pipe(filter((session) => session.sessionId === sessionId));
+  }
+}

--- a/apps/rpg-maestro/src/app/sessions/session-streams.registry.ts
+++ b/apps/rpg-maestro/src/app/sessions/session-streams.registry.ts
@@ -1,0 +1,28 @@
+import { Injectable, Logger } from '@nestjs/common';
+
+/**
+ * How many playing-tracks streams this instance is holding open.
+ *
+ * Worth counting because a stream is a request that never ends: it occupies a connection slot for as
+ * long as a listener stays on the page, so this number — not the request rate — is what tells you how
+ * close an instance is to its concurrency limit. Reported by `GET /health`.
+ */
+@Injectable()
+export class SessionStreamsRegistry {
+  private readonly logger = new Logger(SessionStreamsRegistry.name);
+  private open = 0;
+
+  opened(sessionId: string): void {
+    this.open++;
+    this.logger.debug(`stream opened for session '${sessionId}', ${this.open} open on this instance`);
+  }
+
+  closed(sessionId: string): void {
+    this.open--;
+    this.logger.debug(`stream closed for session '${sessionId}', ${this.open} open on this instance`);
+  }
+
+  get openCount(): number {
+    return this.open;
+  }
+}

--- a/apps/rpg-maestro/src/app/sessions/sessions.module.ts
+++ b/apps/rpg-maestro/src/app/sessions/sessions.module.ts
@@ -1,10 +1,31 @@
-import { Module } from '@nestjs/common';
+import { Logger, Module } from '@nestjs/common';
 import { DatabaseModule } from '../infrastructure/database.module';
 import { SessionsService } from './sessions.service';
+import { SESSION_EVENTS_BROKER, SessionEventsService } from './session-events.service';
+import { InProcessSessionEventsBroker, SessionEventsBroker } from './session-events.broker';
+import { RedisSessionEventsBroker } from './redis-session-events.broker';
+import { sharedRedisUrl } from '../infrastructure/redis/redis-connection';
+import { SessionStreamsRegistry } from './session-streams.registry';
+
+const logger = new Logger('SessionModule');
+
+export function createSessionEventsBroker(): SessionEventsBroker {
+  const url = sharedRedisUrl();
+  if (!url) {
+    return new InProcessSessionEventsBroker();
+  }
+  logger.log('session events fan out over redis pub/sub');
+  return new RedisSessionEventsBroker(url);
+}
 
 @Module({
   imports: [DatabaseModule],
-  providers: [SessionsService],
-  exports: [SessionsService],
+  providers: [
+    SessionsService,
+    SessionEventsService,
+    SessionStreamsRegistry,
+    { provide: SESSION_EVENTS_BROKER, useFactory: createSessionEventsBroker },
+  ],
+  exports: [SessionsService, SessionEventsService, SessionStreamsRegistry],
 })
 export class SessionModule {}

--- a/apps/rpg-maestro/src/app/sessions/sessions.service.ts
+++ b/apps/rpg-maestro/src/app/sessions/sessions.service.ts
@@ -3,13 +3,17 @@ import { DatabaseWrapperConfiguration } from '../DatabaseWrapperConfiguration';
 import { PlayingTrack, SessionPlayingTracks } from '@rpg-maestro/rpg-maestro-api-contract';
 import { TracksDatabase } from '../maestro-api/TracksDatabase';
 import { SessionsCache } from './sessions.cache';
+import { SessionEventsService } from './session-events.service';
 
 @Injectable()
 export class SessionsService {
   private tracksDatabase: TracksDatabase;
   private cache = new SessionsCache();
 
-  constructor(@Inject(DatabaseWrapperConfiguration) databaseWrapper: DatabaseWrapperConfiguration) {
+  constructor(
+    @Inject(DatabaseWrapperConfiguration) databaseWrapper: DatabaseWrapperConfiguration,
+    @Inject(SessionEventsService) private readonly sessionEvents: SessionEventsService
+  ) {
     this.tracksDatabase = databaseWrapper.getTracksDB();
   }
 
@@ -43,12 +47,15 @@ export class SessionsService {
   async upsertCurrentTrack(sessionId: string, playingTrack: PlayingTrack): Promise<SessionPlayingTracks> {
     const updatedSession = await this.tracksDatabase.upsertCurrentTrack(sessionId, playingTrack);
     await this.cache.set(updatedSession);
+    // After the cache, so that a listener woken up by the event reads the new state and not the old one.
+    await this.sessionEvents.publish(updatedSession);
     return updatedSession;
   }
 
   async upsertShortEffectTrack(sessionId: string, playingTrack: PlayingTrack): Promise<SessionPlayingTracks> {
     const updatedSession = await this.tracksDatabase.upsertShortEffectTrack(sessionId, playingTrack);
     await this.cache.set(updatedSession);
+    await this.sessionEvents.publish(updatedSession);
     return updatedSession;
   }
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -18,7 +18,7 @@ currently-playing track in real time via a public player page.
 │  │  Auth0 → JWT         │    │  No auth required                │   │
 │  └──────────┬───────────┘    └─────────────────┬────────────────┘   │
 └─────────────┼───────────────────────────────────┼───────────────────┘
-              │ PUT playing-tracks                 │ GET playing-tracks (poll)
+              │ PUT playing-tracks                 │ SSE playing-tracks/stream (+ fallback poll)
               ▼                                    ▼
 ┌─────────────────────────────────────────────────────────────────────┐
 │                  rpg-maestro (NestJS, port 3000)                     │
@@ -71,13 +71,14 @@ currently-playing track in real time via a public player page.
 
 ```
 AppModule
+├── ClockModule             ServerClock — the clock playback timestamps are stamped in (global)
 ├── DatabaseModule          DB provider (in-memory | firestore)
 ├── MaestroApiModule        Track CRUD, YouTube uploads, playback state
 │   ├── TrackService
 │   ├── ManageCurrentlyPlayingTracks
 │   ├── OnboardingService
 │   └── TrackCreationFromYoutubeJobsWatcher
-├── SessionsModule          Session state
+├── SessionsModule          Session state + SessionEventsService (push fanout)
 ├── UsersManagementModule   User profiles + role management
 ├── TrackCollectionModule   Pre-built collections
 ├── AuthGuardsModule        JWT + RBAC
@@ -91,8 +92,8 @@ AppModule
 | Controller | Base path | Auth |
 |-----------|-----------|------|
 | `AuthenticatedMaestroController` | `/maestro` | JWT + Roles |
-| `PlayersController` | `/` | None |
-| `HealthController` | `/health` | None |
+| `PlayersController` | `/` — incl. `/server-time` and `/sessions/:id/playing-tracks/stream` (SSE) | None |
+| `HealthController` | `/health` — status, plus `playback` diagnostics (clock reference, offset, open streams) | None |
 | `TestsUtilsController` | `/test-utils` | None (dev only) |
 
 **Environment variables:**
@@ -184,6 +185,7 @@ Core types shared between backend and frontend:
 | `Track` | Track entity (id, sessionId, url, name, duration, tags, source) |
 | `PlayingTrack` | Track with playback state (isPaused, playTimestamp, trackStartTime) |
 | `SessionPlayingTracks` | Session state (currentTrack, shortEffectTrack) |
+| `ServerTime` | `{ serverTime }` — the clock `playTimestamp` is expressed in |
 | `User` | User entity (id, role, sessions) |
 | `TrackCollection` | Curated collection with tracks |
 | `TrackCreation` / `TrackUpdate` | Request DTOs |
@@ -319,17 +321,64 @@ Browser                       Backend
 
 ---
 
-## Real-Time Playback (Polling)
+## Real-Time Playback (SSE push, with polling as a safety net)
 
-No WebSockets. Audience pages poll `/sessions/:id/playing-tracks` every N seconds.
-Maestro writes state via `PUT /maestro/sessions/:sessionId/playing-tracks`.
+The Maestro writes state via `PUT /maestro/sessions/:sessionId/playing-tracks`. Listeners get it
+pushed over server-sent events, and poll only as a fallback.
 
 **`PlayingTrack` fields enable client-side sync:**
-- `playTimestamp` — wall-clock time when playback started
-- `trackStartTime` — position in seconds where playback began
+- `playTimestamp` — time on the **server clock** when playback started
+- `trackStartTime` — position in the track where playback began
 - `isPaused` — pause state
 
-Client reconstructs current position as `(Date.now() - playTimestamp) / 1000 + trackStartTime`.
+Client reconstructs the position as `(serverNow() - playTimestamp) + trackStartTime`, modulo the
+track duration.
+
+### Push channel
+
+```
+Maestro's write                                        Listener's browser
+      │                                                        │
+      ▼                                                        │  EventSource
+ SessionsService.upsertCurrentTrack                            │  GET /sessions/:id/playing-tracks/stream
+      │ writes DB + cache                                      ▼
+      └─► SessionEventsService.publish ──► broker ──► every instance ──► @Sse handler
+                                             │                            (snapshot, then changes,
+   CACHE_REDIS_URL set  → redis pub/sub ─────┘                             plus a 20s heartbeat)
+   nothing set          → in-process (single instance only)
+```
+
+- **SSE, not WebSocket**: everything flows server→client, and a plain GET needs no sticky sessions —
+  any instance can serve any listener because the fanout is in the broker.
+- **Fanout over Redis pub/sub** (`sessions/redis-session-events.broker.ts`), one channel for all
+  sessions, filtered by session id on receipt. Track changes are rare enough that per-session channels
+  would only add a subscribe/unsubscribe dance per stream.
+- **Events are whole snapshots**, so a dropped event costs nothing once the next one lands, and the
+  client runs the same `resolveSync` for pushed and polled state.
+- **The poll stays** at `SYNC_TRACK_FALLBACK_INTERVAL_MS` (15s) while the stream is up, and at
+  `SYNC_TRACK_INTERVAL_MS` (1s) while it is down. Losing the push path degrades latency, never
+  correctness — which is also why nothing in the publish path can fail a Maestro's write.
+- **Observability.** `GET /health` reports `playback.clockOffsetMs`, `playback.clockReference` and
+  `playback.openStreams`. Skew and stream load are otherwise invisible: neither raises an error, and
+  both are only noticed by a listener saying the music is out of sync. `openStreams` is the number to
+  watch against an instance's concurrency limit, since a stream holds its connection for as long as a
+  listener stays on the page.
+
+### Time authority
+
+`playTimestamp` is meaningless unless everyone agrees on the clock it was stamped in. Two skews had to
+be removed, and they need different answers:
+
+| Skew | Answer |
+|------|--------|
+| Between instances — a change stamped by pod A, the next by pod B | **Server-authoritative clock.** `ServerClock` (`infrastructure/clock/`) corrects the local clock against a single reference: Redis' `TIME`, NTP-style, best-of-5-samples, resynced every 30s. Every pod then stamps the same instant. |
+| Between server and browser — laptop clocks are routinely seconds off | **Client-negotiated offset.** The browser measures its offset against `GET /server-time` (same estimator, resynced every 5 min) and `serverNow()` returns the corrected clock. `getCurrentPlayTime(serverNowMs)` takes it as an argument, so no caller can silently reach for `Date.now()`. |
+
+Redis is the reference because it is already the piece every instance shares, and `TIME` costs no
+write — unlike a database server timestamp. With no Redis configured (local dev, e2e, single instance)
+the offset stays 0 and the local clock is the authority, which is correct there: there is only one
+clock in play. If the reference is unreachable the last known offset is kept, so playback drifts at
+worst rather than stopping.
 
 ---
 
@@ -365,7 +414,9 @@ Client reconstructs current position as `(Date.now() - playTimestamp) / 1000 + t
 | Pluggable DB (in-memory / Firestore) | Fast local dev without cloud deps |
 | Separate audio-file-uploader service | Isolates FFmpeg/ytdl complexity + heavy file I/O |
 | Shared API contracts in libs | Single source of truth, compile-time type safety |
-| Polling for real-time sync | Simpler than WebSockets; acceptable latency for RPG use case |
+| SSE push + slow fallback poll | Polling alone scales with the number of listeners; SSE needs no sticky sessions, and the poll left underneath means a cut stream costs latency, not correctness |
+| Redis `TIME` as the playback clock | Instance clocks drift apart, and that drift is audible. Redis is already shared by every instance and needs no write to be read, unlike a DB server timestamp |
+| Clients negotiate their own clock offset | Even one instance cannot fix a listener's own clock being seconds off, and that error lands straight on the playhead |
 | Fake IDP for dev | No Auth0 tenant required for local dev |
 | MUI dark theme | Fits the RPG atmosphere; consistent component library |
 | Role enum (MAESTRO/MINSTREL/ADMIN) | Granular access control without OAuth scopes |

--- a/docs/dev-guide.md
+++ b/docs/dev-guide.md
@@ -67,6 +67,10 @@ npx nx deploy rpg-maestro
 cache stays in-process, which is what local dev and the e2e tests use. See
 [architecture.md](architecture.md) for the tier switching rules.
 
+The same Redis (primary if set, else the fallback) is also the playback time reference and the pub/sub
+fanout for the SSE push channel. With neither set, the local clock is the time authority and session
+events stay in-process — correct for a single instance, and only for a single instance.
+
 ## Adding a New Feature — Checklist
 
 1. **Backend module** — create under `apps/rpg-maestro/src/app/<module>/`

--- a/libs/rpg-maestro-api-contract/src/index.ts
+++ b/libs/rpg-maestro-api-contract/src/index.ts
@@ -7,6 +7,7 @@ export * from './lib/TracksFromDirectoryCreation';
 export * from './lib/TrackToPlay';
 export * from './lib/Tag';
 export * from './lib/SessionPlayingTracks';
+export * from './lib/ServerTime';
 export * from './lib/ChangeSessionPlayingTracksRequest';
 export * from './lib/upload-track-from-youtube/UploadAndCreateTracksFromYoutubeRequest';
 export * from './lib/upload-track-from-youtube/UploadAndCreateTracksFromYoutubeResponse';

--- a/libs/rpg-maestro-api-contract/src/lib/PlayingTrack.spec.ts
+++ b/libs/rpg-maestro-api-contract/src/lib/PlayingTrack.spec.ts
@@ -1,10 +1,6 @@
-import { PlayingTrack } from "./PlayingTrack";
+import { CLOCK_SKEW_TOLERANCE_MS, PlayingTrack } from "./PlayingTrack";
 
-const NOW = new Date(1730000015000);
-
-beforeAll(() => {
-  vitest.useFakeTimers().setSystemTime(NOW);
-});
+const SERVER_NOW = 1730000015000;
 
 describe("PlayingTrack getCurrentPlayTime()", () => {
   it("should return last track start time when it was paused", () => {
@@ -17,22 +13,45 @@ describe("PlayingTrack getCurrentPlayTime()", () => {
       Number.MIN_VALUE,
       10563
     );
-    expect(pausedTrack.getCurrentPlayTime()).toBe(10563);
+    expect(pausedTrack.getCurrentPlayTime(SERVER_NOW)).toBe(10563);
   });
-  it("should raise error when the track is set to play in the future", () => {
+  it("should start the track from the beginning, loudly, when the clock it is compared against is broken", () => {
+    // Only a caller whose idea of the server clock is wrong sees a timestamp in the future — the server
+    // never stamps one. Playing from the requested start beats refusing to play.
+    const warn = vitest.spyOn(console, 'warn').mockImplementation(() => undefined);
     const playingTrack = new PlayingTrack(
       "id1",
       "name1",
       "url",
       120000,
       false,
-      Number.MAX_VALUE,
-      0
+      SERVER_NOW + 60 * 60 * 1000,
+      3000
     );
-    expect(() => playingTrack.getCurrentPlayTime()).toThrow('this.playTimestamp in the future are not handled');
+
+    expect(playingTrack.getCurrentPlayTime(SERVER_NOW)).toBe(3000);
+    expect(warn).toHaveBeenCalledOnce();
+    warn.mockRestore();
+  });
+  it("should start where the track was asked to start when the clock estimate is off by less than the tolerance", () => {
+    // What a client sees when its measured offset is a few dozen milliseconds optimistic: the timestamp
+    // reads as barely in the future, which is measurement noise rather than a broken clock.
+    const playTimestampSlightlyAhead = SERVER_NOW + CLOCK_SKEW_TOLERANCE_MS - 1;
+    const trackStartTime20s = 20000;
+
+    const playingTrack = new PlayingTrack(
+      "id1",
+      "name1",
+      "url",
+      120000,
+      false,
+      playTimestampSlightlyAhead,
+      trackStartTime20s
+    );
+    expect(playingTrack.getCurrentPlayTime(SERVER_NOW)).toBe(trackStartTime20s);
   });
   it("should return the current time the track is playing when it was started from 0", () => {
-    const playTimestamp15sAgo = NOW.getTime() - 15000;
+    const playTimestamp15sAgo = SERVER_NOW - 15000;
     const trackStartTime = 0;
 
     const playingTrack = new PlayingTrack(
@@ -44,10 +63,10 @@ describe("PlayingTrack getCurrentPlayTime()", () => {
       playTimestamp15sAgo,
       trackStartTime
     );
-    expect(playingTrack.getCurrentPlayTime()).toBe(15000);
+    expect(playingTrack.getCurrentPlayTime(SERVER_NOW)).toBe(15000);
   });
   it("should return the current time the track is playing when it was already started", () => {
-    const playTimestamp15sAgo = NOW.getTime() - 15000;
+    const playTimestamp15sAgo = SERVER_NOW - 15000;
     const trackStartTime20s = 20000;
 
     const playingTrack = new PlayingTrack(
@@ -59,10 +78,10 @@ describe("PlayingTrack getCurrentPlayTime()", () => {
       playTimestamp15sAgo,
       trackStartTime20s
     );
-    expect(playingTrack.getCurrentPlayTime()).toBe(35000);
+    expect(playingTrack.getCurrentPlayTime(SERVER_NOW)).toBe(35000);
   });
   it("should handle the track looping when finished when starting from 0", () => {
-    const playTimestamp = NOW.getTime() - 230000;
+    const playTimestamp = SERVER_NOW - 230000;
     const trackStartTime = 0;
     const duration = 120000;
 
@@ -75,6 +94,17 @@ describe("PlayingTrack getCurrentPlayTime()", () => {
       playTimestamp,
       trackStartTime
     );
-    expect(playingTrack.getCurrentPlayTime()).toBe(110000);
+    expect(playingTrack.getCurrentPlayTime(SERVER_NOW)).toBe(110000);
+  });
+  it("should ignore this machine's own clock, and use only the server clock it is given", () => {
+    // The whole point of the parameter: a browser three hours behind still lands on the playhead
+    // everyone else is at, because it corrected for its offset before calling this.
+    vitest.useFakeTimers().setSystemTime(new Date(SERVER_NOW - 3 * 60 * 60 * 1000));
+    try {
+      const playingTrack = new PlayingTrack("id1", "name1", "url", 120000, false, SERVER_NOW - 15000, 0);
+      expect(playingTrack.getCurrentPlayTime(SERVER_NOW)).toBe(15000);
+    } finally {
+      vitest.useRealTimers();
+    }
   });
 });

--- a/libs/rpg-maestro-api-contract/src/lib/PlayingTrack.ts
+++ b/libs/rpg-maestro-api-contract/src/lib/PlayingTrack.ts
@@ -1,3 +1,10 @@
+/**
+ * How far in the future a `playTimestamp` may sit before it is worth complaining about. A client's
+ * estimate of the server clock is only as good as the round trip it measured it with, so a change
+ * stamped a moment ago can legitimately read as "in the future".
+ */
+export const CLOCK_SKEW_TOLERANCE_MS = 2000;
+
 export class PlayingTrack {
   id: string;
   name: string;
@@ -26,14 +33,32 @@ export class PlayingTrack {
     this.trackStartTime = trackStartTime;
   }
 
-  getCurrentPlayTime(): number {
-    if (this.playTimestamp > Date.now()) {
-      throw new Error('this.playTimestamp in the future are not handled');
-    }
+  /**
+   * Where the playhead should be right now.
+   *
+   * @param serverNowMs epoch ms **on the server clock**, the clock `playTimestamp` was stamped in.
+   * Callers in the browser must not pass `Date.now()`: browser clocks are routinely seconds off, and
+   * that error lands straight on the playhead, leaving every listener somewhere else in the track. Use
+   * `serverNow()` from `utils/server-time.ts` instead.
+   */
+  getCurrentPlayTime(serverNowMs: number): number {
     if (this.isPaused) {
       return this.trackStartTime;
     }
-    const elapsedPlayTime = Date.now() - this.playTimestamp;
+    const elapsedPlayTime = serverNowMs - this.playTimestamp;
+    if (elapsedPlayTime < 0) {
+      // A timestamp in the future means the caller's idea of the server clock is wrong — the server
+      // never stamps one. Within the tolerance that is just noise in the offset measurement; beyond it
+      // the clock estimate is broken, and there is no playhead to compute from it. Either way the
+      // track starts where it was asked to start, because refusing to play at all would be worse than
+      // starting a few seconds early.
+      if (elapsedPlayTime < -CLOCK_SKEW_TOLERANCE_MS) {
+        console.warn(
+          `playTimestamp is ${-elapsedPlayTime}ms in the future, the clock this was compared against is off`
+        );
+      }
+      return this.trackStartTime % this.duration;
+    }
     const timeTheTrackWasPlayed = elapsedPlayTime + this.trackStartTime;
     return timeTheTrackWasPlayed % this.duration;
   }

--- a/libs/rpg-maestro-api-contract/src/lib/ServerTime.ts
+++ b/libs/rpg-maestro-api-contract/src/lib/ServerTime.ts
@@ -1,0 +1,11 @@
+/**
+ * The server's own clock, as read when the request was handled.
+ *
+ * Clients need this because `PlayingTrack.playTimestamp` is expressed on the server clock, and a
+ * browser's `Date.now()` is routinely seconds away from it. Reconstructing a playhead by mixing the
+ * two makes every listener sit at a different position in the track.
+ */
+export interface ServerTime {
+  /** Epoch ms on the server clock. */
+  serverTime: number;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "@nestjs/serve-static": "^5.0.0",
         "@nestjs/swagger": "^11.0.0",
         "@nestjs/terminus": "^11.0.0",
+        "@redis/client": "^5.12.1",
         "axios": "^1.6.0",
         "class-transformer": "^0.5.1",
         "class-validator": "^0.14.2",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "@nestjs/serve-static": "^5.0.0",
     "@nestjs/swagger": "^11.0.0",
     "@nestjs/terminus": "^11.0.0",
+    "@redis/client": "^5.12.1",
     "axios": "^1.6.0",
     "class-transformer": "^0.5.1",
     "class-validator": "^0.14.2",


### PR DESCRIPTION
Closes #116.

## The decision on time authority

The issue framed server-authoritative vs. client-negotiated as an either/or. They fix two different skews, so this does both:

| Skew | Answer |
|---|---|
| Between instances — one change stamped by pod A, the next by pod B | **Server-authoritative clock.** `ServerClock` corrects the local clock against Redis' `TIME` (NTP-style estimator, best-of-5 samples by shortest round trip, resynced every 30s). Redis because it is already the piece every instance shares and needs no write to be read, unlike a Firestore server timestamp which would cost a round trip *and* a write per track change. |
| Between server and browser — laptop clocks are routinely seconds off | **Client-negotiated offset** against `GET /server-time`, with `serverNow()` feeding every playhead computation. `getCurrentPlayTime(serverNowMs)` now takes the clock as an argument so no call site can silently reach for `Date.now()`. |

With no shared Redis (local dev, e2e, single instance) the offset stays 0 and the local clock is the authority — correct there, since there is only one clock in play.

## Push channel

`@Sse /sessions/:id/playing-tracks/stream` opens with a snapshot, then pushes each change, plus a 20s heartbeat so proxies do not reap an idle stream. Fanout across instances goes over Redis pub/sub. SSE rather than a WebSocket: everything flows server→client, and a plain GET needs no sticky sessions.

Polling stays underneath as a safety net — 15s while the stream is up, 1s while it is down — so losing the push path costs latency, never correctness. Nothing in the publish path can fail a Maestro's write.

## Deploy notes

- **Rolling deploys are safe in both directions.** Old UI + new backend computes exactly as it does today; new UI + old backend gets a 404 on `/server-time` (offset stays 0) and on the stream (falls back to 1s polling). UI and backend need not ship together.
- `GET /server-time` is `Cache-Control: no-store`. A cache in front of it would hand everyone behind it the same frozen instant, turning the fix for skew into a source of it.
- **Whatever fronts this must not buffer `text/event-stream`,** and its idle timeout must exceed the 20s heartbeat. On a platform with per-instance request concurrency, a stream occupies one slot for its whole life, so `playback.openStreams` on `/health` is the number to watch.
- **Known limitation:** an instance that boots while the *primary* Redis is unreachable stays on offset 0 even if the fallback Redis is up. The clock deliberately does not fail over, because instances disagreeing about which clock to trust is worse than instances slightly skewed.

## Verification

- `nx run-many -t lint test build --all`: 8 projects, 155 unit tests, 0 lint errors.
- 20/20 Playwright tests, including a new one that **blocks the polling endpoint outright** and asserts the player still gets the initial state and the next change — so the push path cannot rot behind a poll covering for it.
- `players.e2e.spec.ts` drives a real SSE connection over HTTP: snapshot, pushed change, 404 for a missing session, and the `/health` stream count going up and back down.
- **Manual, two instances against real Redis:** both clocks agreed within 13ms and matched Redis' `TIME`; a write on instance A reached a listener streamed from instance B; killing Redis left both serving on the last known offset with warnings and no crash; restarting it resumed fanout without a restart.

## Also in here

Two findings from QA that predate this work:

- `fix(ui)`: pausing while a `play()` was starting logged `AbortError` as "An unexpected error occurred". The pause is the newer intent and already won. Both players had drifted into two copies of that catch block, so the sorting of `play()` rejections now lives in one place.
- `feat(health)`: clock offset and open stream count on `/health` — neither failure mode raises an error, so both were invisible until a listener complained.
- A new e2e test drives the **Maestro** audio player in a browser, which nothing did before: the rest of the suite only loads it as a side effect of the soundboard.

Left deliberately out of scope: with Redis unreachable, `GET /sessions/:id/playing-tracks` hangs rather than failing fast into the database. Pre-existing in `ResilientCache` (confirmed against `main`), but SSE makes it worse in kind since stream opens fetch a snapshot too. Filed separately.