### PR TITLE
fix(cache): bound every cache tier operation so an unreachable Redis misses instead of hanging

### DIFF
--- a/apps/rpg-maestro/src/app/infrastructure/cache/resilient-cache.spec.ts
+++ b/apps/rpg-maestro/src/app/infrastructure/cache/resilient-cache.spec.ts
@@ -1,38 +1,54 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { CacheStore, CacheTier, FAILURE_THRESHOLD, PROBE_INTERVAL_MS, ResilientCache } from './resilient-cache';
+import {
+  CacheStore,
+  CacheTier,
+  FAILURE_THRESHOLD,
+  PROBE_INTERVAL_MS,
+  ResilientCache,
+  TIER_OPERATION_TIMEOUT_MS,
+} from './resilient-cache';
 
 class FakeStore implements CacheStore<string> {
   readonly entries = new Map<string, string>();
   /** When true every operation rejects, as a real backend would while it is unreachable. */
   down = false;
+  /**
+   * When true no operation ever settles, the way node-redis queues commands while its connection is
+   * down. This, not `down`, is how an unreachable Redis actually behaves.
+   */
+  hangs = false;
   readonly calls: string[] = [];
 
   async get(key: string): Promise<string | undefined> {
-    this.record('get');
+    await this.record('get');
     return this.entries.get(key);
   }
 
   async set(key: string, value: string): Promise<unknown> {
-    this.record('set');
+    await this.record('set');
     return this.entries.set(key, value);
   }
 
   async delete(key: string): Promise<unknown> {
-    this.record('delete');
+    await this.record('delete');
     return this.entries.delete(key);
   }
 
   async clear(): Promise<unknown> {
-    this.record('clear');
+    await this.record('clear');
     this.entries.clear();
     return undefined;
   }
 
-  private record(operation: string): void {
+  private record(operation: string): Promise<void> {
     this.calls.push(operation);
     if (this.down) {
       throw new Error(`backend is down, cannot ${operation}`);
     }
+    if (this.hangs) {
+      return new Promise<void>(() => undefined);
+    }
+    return Promise.resolve();
   }
 }
 
@@ -40,6 +56,12 @@ describe('ResilientCache', () => {
   let primary: FakeStore;
   let fallback: FakeStore;
   let cache: ResilientCache<string>;
+
+  /** Lets the operation timeout fire, which is the only thing a hanging tier ever waits for. */
+  const pastTheTimeout = async <R>(pending: Promise<R>): Promise<R> => {
+    await vi.advanceTimersByTimeAsync(TIER_OPERATION_TIMEOUT_MS);
+    return pending;
+  };
 
   const knockOutPrimary = async (): Promise<void> => {
     primary.down = true;
@@ -171,6 +193,69 @@ describe('ResilientCache', () => {
 
     expect(primary.entries.has('session-1')).toBe(false);
     expect(fallback.entries.has('session-1')).toBe(false);
+  });
+
+  describe('when a tier hangs instead of failing', () => {
+    const hangPrimary = async (): Promise<void> => {
+      primary.hangs = true;
+      for (let i = 0; i < FAILURE_THRESHOLD; i++) {
+        await pastTheTimeout(cache.get('any-key'));
+      }
+    };
+
+    it('answers a read with a miss instead of waiting for the tier', async () => {
+      primary.hangs = true;
+
+      await expect(pastTheTimeout(cache.get('session-1'))).resolves.toBeUndefined();
+    });
+
+    it('lets a write through instead of waiting for the tier', async () => {
+      primary.hangs = true;
+
+      await expect(pastTheTimeout(cache.set('session-1', 'tavern'))).resolves.toBeUndefined();
+    });
+
+    it('takes the tier out of rotation, so the fallback serves the next calls', async () => {
+      await hangPrimary();
+
+      await cache.set('session-1', 'tavern');
+
+      expect(fallback.entries.get('session-1')).toBe('tavern');
+      await expect(cache.get('session-1')).resolves.toBe('tavern');
+    });
+
+    it('stops calling the hanging tier once it is out of rotation', async () => {
+      await hangPrimary();
+      const callsWhenKnockedOut = primary.calls.length;
+
+      await cache.get('session-1');
+      await cache.set('session-1', 'tavern');
+
+      expect(primary.calls.length).toBe(callsWhenKnockedOut);
+    });
+
+    it('keeps the tier out of rotation when its recovery probe hangs', async () => {
+      await hangPrimary();
+
+      vi.advanceTimersByTime(PROBE_INTERVAL_MS);
+      await pastTheTimeout(cache.set('session-1', 'tavern'));
+
+      expect(fallback.entries.get('session-1')).toBe('tavern');
+      expect(primary.entries.size).toBe(0);
+    });
+
+    it('degrades to no cache at all when every tier hangs', async () => {
+      await hangPrimary();
+      fallback.hangs = true;
+      for (let i = 0; i < FAILURE_THRESHOLD; i++) {
+        await pastTheTimeout(cache.get('any-key'));
+      }
+      const callsWhenAllDown = primary.calls.length + fallback.calls.length;
+
+      await expect(cache.set('session-1', 'tavern')).resolves.toBeUndefined();
+      await expect(cache.get('session-1')).resolves.toBeUndefined();
+      expect(primary.calls.length + fallback.calls.length).toBe(callsWhenAllDown);
+    });
   });
 
   it('behaves like a plain cache when a single tier is configured', async () => {

--- a/apps/rpg-maestro/src/app/infrastructure/cache/resilient-cache.ts
+++ b/apps/rpg-maestro/src/app/infrastructure/cache/resilient-cache.ts
@@ -24,6 +24,14 @@ export const FAILURE_THRESHOLD = 3;
 /** How long a tier stays out of rotation before the next operation probes it again. */
 export const PROBE_INTERVAL_MS = ms('30s');
 
+/**
+ * Longest a single tier operation may take before it counts as a failure. This is a cache: a hit
+ * slower than the database is worthless. It also guards against a backend that neither answers nor
+ * fails — node-redis queues commands while its connection is down, so an unreachable Redis leaves
+ * every operation pending forever instead of rejecting.
+ */
+export const TIER_OPERATION_TIMEOUT_MS = ms('300ms');
+
 interface TierState {
   consecutiveFailures: number;
   /** Epoch ms before which the tier must not be called. `null` means the tier is healthy. */
@@ -61,7 +69,7 @@ export class ResilientCache<T> {
       return undefined;
     }
     try {
-      const value = await tier.store.get(key);
+      const value = await this.withTimeout(tier, () => tier.store.get(key));
       this.stateOf(tier).consecutiveFailures = 0;
       return value;
     } catch (error) {
@@ -109,7 +117,7 @@ export class ResilientCache<T> {
       // `clear` doubles as the connectivity probe and as the wipe of data that went stale while the
       // tier was missing invalidations.
       try {
-        await tier.store.clear();
+        await this.withTimeout(tier, () => tier.store.clear());
         this.logger.log(`cache tier "${tier.name}" recovered, its namespace was cleared`);
         state.consecutiveFailures = 0;
         state.unhealthyUntil = null;
@@ -123,10 +131,32 @@ export class ResilientCache<T> {
 
   private async run(tier: CacheTier<T>, operation: () => Promise<unknown>): Promise<void> {
     try {
-      await operation();
+      await this.withTimeout(tier, operation);
       this.stateOf(tier).consecutiveFailures = 0;
     } catch (error) {
       this.recordFailure(tier, error);
+    }
+  }
+
+  /**
+   * Rejects if `operation` has not settled within {@link TIER_OPERATION_TIMEOUT_MS}, so a backend
+   * that hangs is recorded as failing and ends up out of rotation like one that rejects. The
+   * abandoned operation keeps running, but the race already handles its outcome either way.
+   */
+  private async withTimeout<R>(tier: CacheTier<T>, operation: () => Promise<R>): Promise<R> {
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    try {
+      return await Promise.race([
+        operation(),
+        new Promise<never>((_resolve, reject) => {
+          timer = setTimeout(
+            () => reject(new Error(`cache tier "${tier.name}" did not answer within ${TIER_OPERATION_TIMEOUT_MS}ms`)),
+            TIER_OPERATION_TIMEOUT_MS
+          );
+        }),
+      ]);
+    } finally {
+      clearTimeout(timer);
     }
   }
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -270,6 +270,12 @@ the database absorbs the traffic until a tier comes back.
 `PROBE_INTERVAL_MS`; after that the next operation probes it. Without this, an outage that lasts
 hours would cost a connection timeout on every single request.
 
+**Every tier operation is bounded by `TIER_OPERATION_TIMEOUT_MS`, and a timeout counts as a
+failure.** This is what makes the degradation above real: an unreachable Redis does not reject, it
+*queues* commands in node-redis until the connection is back, so without a deadline nothing ever
+fails, no tier is ever taken out of rotation, and callers wait instead of reaching the database. The
+deadline is short on purpose — a cache hit slower than Firestore is worthless.
+
 **Two rules keep a dormant tier from waking up with stale data**, given that writes only ever reach
 the active tier:
 


### PR DESCRIPTION
Closes #120.

## Reproduced

A tier that never settles (which is how an unreachable Redis behaves — node-redis queues commands while the connection is down rather than rejecting) makes `ResilientCache.get()` never resolve:

```
✗ get() resolves even when the only tier never settles
  AssertionError: expected 'hung' to be 'settled'
```

The existing spec's fake rejects, so health switching worked there and the real failure mode was never covered. Because nothing rejects, `consecutiveFailures` never reaches `FAILURE_THRESHOLD`, the tier is never taken out of rotation, and callers wait instead of falling through to Firestore. `GET /sessions/:id/playing-tracks` therefore hangs for the length of the outage — and with the SSE push channel, every stream open hangs too since it fetches a snapshot first.

## Fix

Every tier operation — reads, writes, cross-tier invalidations, and the recovery probe — is raced against `TIER_OPERATION_TIMEOUT_MS` (300ms; a cache hit slower than the database is worthless), and a timeout is recorded through the same `recordFailure` path as a rejection. The existing `FAILURE_THRESHOLD` / `PROBE_INTERVAL_MS` switching then takes the tier out of rotation, so the documented "degrades to no cache at all, not to a slower one" guarantee holds again.

## Tests

New `describe('when a tier hangs instead of failing')` block driving a store whose operations never settle:

- a read answers with a miss, a write returns, both bounded by the timeout
- after `FAILURE_THRESHOLD` timeouts the tier leaves rotation and the fallback serves
- the hanging tier stops being called during cooldown
- a hanging recovery probe keeps the tier out of rotation
- with every tier hanging the cache degrades to no cache at all

`nx test rpg-maestro` (which runs lint and build first): 73 tests pass.